### PR TITLE
Only enable password entry fields when option is checked

### DIFF
--- a/MacPass/MPPasswordEditWindowController.h
+++ b/MacPass/MPPasswordEditWindowController.h
@@ -30,6 +30,7 @@
 @property (weak) IBOutlet NSButton *togglePasswordButton;
 @property (weak) IBOutlet NSTextField *errorTextField;
 @property (weak) IBOutlet NSButton *changePasswordButton;
+@property (weak) IBOutlet NSButton *hasPasswordSwitchButton;
 @property (nonatomic,assign) BOOL allowsEmptyPasswordOrKey;
 
 @property (weak) id<MPPasswordEditWindowDelegate> delegate;

--- a/MacPass/MPPasswordEditWindowController.m
+++ b/MacPass/MPPasswordEditWindowController.m
@@ -56,8 +56,10 @@
   
   NSDictionary *negateOption = @{ NSValueTransformerNameBindingOption : NSNegateBooleanTransformerName };
   [self.passwordTextField bind:@"showPassword" toObject:self withKeyPath:@"showPassword" options:nil];
+  [self.passwordTextField bind:NSEnabledBinding toObject:self.hasPasswordSwitchButton withKeyPath:@"cell.state" options:nil];
   [self.togglePasswordButton bind:NSValueBinding toObject:self withKeyPath:@"showPassword" options:nil];
   [self.passwordRepeatTextField bind:NSEnabledBinding toObject:self withKeyPath:@"showPassword" options:negateOption];
+  [self.passwordRepeatTextField bind:NSEnabledBinding toObject:self.hasPasswordSwitchButton withKeyPath:@"cell.state" options:nil];
   [self.errorTextField bind:NSHiddenBinding toObject:self withKeyPath:@"hasValidPasswordOrKey" options:nil];
   [self.changePasswordButton bind:NSEnabledBinding toObject:self withKeyPath:@"hasValidPasswordOrKey" options:nil];
   [self.keyfilePathControl bind:NSValueBinding toObject:self withKeyPath:@"keyURL" options:nil];

--- a/MacPass/PasswordEditWindow.xib
+++ b/MacPass/PasswordEditWindow.xib
@@ -9,6 +9,7 @@
             <connections>
                 <outlet property="changePasswordButton" destination="68" id="85"/>
                 <outlet property="errorTextField" destination="12" id="79"/>
+                <outlet property="hasPasswordSwitchButton" destination="yKc-I9-uzv" id="aUH-R4-WwP"/>
                 <outlet property="keyfilePathControl" destination="4" id="63"/>
                 <outlet property="passwordRepeatTextField" destination="11" id="62"/>
                 <outlet property="passwordTextField" destination="9" id="61"/>


### PR DESCRIPTION
Enables or disables the two password fields on the change-password window when the corresponding check box is checked or unchecked.

This isn't totally finished, since it should probably also clear the boxes when unchecked.
