### PR TITLE
Fixes search field (Issue #65)

### DIFF
--- a/MacPass/FilterBar.xib
+++ b/MacPass/FilterBar.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13A2093" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment defaultVersion="1080" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
@@ -87,6 +87,9 @@
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </searchFieldCell>
+                    <connections>
+                        <outlet property="delegate" destination="-2" id="Y78-7K-e9c"/>
+                    </connections>
                 </searchField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="96">
                     <rect key="frame" x="238" y="6" width="74" height="17"/>

--- a/MacPass/MPEntryViewController.m
+++ b/MacPass/MPEntryViewController.m
@@ -342,6 +342,10 @@ NSString *const _MPTAbleSecurCellView = @"PasswordCell";
 #pragma mark Filtering
 
 - (void)showFilter:(id)sender {
+  if([self _showsFilterBar]) {
+    [self.filterSearchField selectText:self];
+  }
+  
   [self _showFilterBarAnimated];
 }
 
@@ -409,6 +413,17 @@ NSString *const _MPTAbleSecurCellView = @"PasswordCell";
 - (void)updateFilterText:(id)sender {
   self.filter = [self.filterSearchField stringValue];
 }
+
+- (BOOL)control:(NSControl*)control textView:(NSTextView*)textView doCommandBySelector:(SEL)commandSelector
+{
+    if (commandSelector == @selector(insertNewline:))
+    {
+        self.filter = [self.filterSearchField stringValue];
+    }
+    
+    return NO;
+}
+
 
 - (void)_setupFilterBar {
   if(!self.filterBar) {


### PR DESCRIPTION
Cmd+F now marks the text of the search field if the filterbar is already visible and sets the focus. So the user can now start typing it's new search term immediately after pressing Cmd+F instead of clearing the field manually.

Also the hitting the Return key while entering the search term now fires the updateFilter. Previously the filter has not been updated if the user pressed the Return key before the last actual keystroke.

Beware: I have no experience whatsoever in OS-X coding and Objective-C. However it does what I wanted it to do; see for yourself if it's implemented the 'right way'.
