### PR TITLE
Set remaining password fields to fixed width font (#97)

### DIFF
--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -79,7 +79,7 @@ DQ
                         <constraint firstAttribute="width" constant="191" id="389"/>
                     </constraints>
                     <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Enter Password" drawsBackground="YES" usesSingleLineMode="YES" id="339">
-                        <font key="font" metaFont="system"/>
+                        <font key="font" size="13" name="Menlo-Regular"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         <allowedInputSourceLocales>

--- a/MacPass/EntryInspectorView.xib
+++ b/MacPass/EntryInspectorView.xib
@@ -610,7 +610,7 @@
                     <rect key="frame" x="20" y="475" width="173" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="63">
-                        <font key="font" metaFont="system"/>
+                        <font key="font" size="13" name="Menlo-Regular"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         <allowedInputSourceLocales>


### PR DESCRIPTION
Sets the password field of Password Input view and the Inspector view to Menlo-Regular 13 (as it is set for the password generator)

Fixes #97
