### PR TITLE
Implementation of fix for issue #118

### DIFF
--- a/MacPass/MPIconHelper.h
+++ b/MacPass/MPIconHelper.h
@@ -73,15 +73,15 @@ typedef NS_ENUM(NSUInteger, MPIconType) {
 + (NSDictionary *)availableIconNames;
 
 /**
- *	List of all availabel DatabaseIcons as Images. Sorted by IconIndex
+ *	List of all available DatabaseIcons as an array of Images. Sorted by IconIndex.
  *	@return	Array of Icons as NSImage objects
  */
 + (NSArray *)databaseIcons;
 
 /**
- *	List of all available DatabaseIcons as MPIconType. Sorted by IconIndex
- *	@return	Array of Names as NSNumber objects
+ *	List of all available DatabaseIcons as an array of MPIconType. Sorted by IconIndex.
+ *	@return	Array of MPIconType as NSNumber objects
  */
-+ (NSArray *)databaseIconType;
++ (NSArray *)databaseIconTypes;
 
 @end

--- a/MacPass/MPIconHelper.m
+++ b/MacPass/MPIconHelper.m
@@ -47,7 +47,7 @@
 }
 
 
-+ (NSArray *)databaseIconType {
++ (NSArray *)databaseIconTypes {
     static NSArray *iconTypes;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/MacPass/MPIconSelectViewController.m
+++ b/MacPass/MPIconSelectViewController.m
@@ -58,7 +58,7 @@ NSInteger const kMPDefaultIcon = -1;
   NSButton *button = sender;
   NSImage *image = [button image];
   NSUInteger buttonIndex = [[self.iconCollectionView content] indexOfObject:image];
-  self.selectedIcon = [[MPIconHelper databaseIconType] [buttonIndex] integerValue];
+  self.selectedIcon = [[MPIconHelper databaseIconTypes] [buttonIndex] integerValue];
   [self.popover performClose:self];
 }
 


### PR DESCRIPTION
Dear mrstarke,

Great work on the MacPass implementation! Much of an improvement over the KeePassX UI. 
# Problem

While using MacPass, I encountered a bug with the database icons, which is already in the issue list as issue #118. An example of the problem can be seen by selecting the 5th database icon (Terminal) which will cause the icon with key 1006 (Triangle) to be selected. 
# Analysis

The window with the database icons is filled using the data from the NSArray returned by databaseIcons. This list is based on the NSDictionary returned by databaseIconTypes, but with certain icons (with an ID >= 1000) removed. When an icon has been selected, the selected icon is identified as an index from the databaseIcons NSArray, and the corresponding MPIconType ID is retrieved from the databaseIconTypes NSDictionary using this index.  (See line 61 from MacPass/MPIconSelectViewController.m) However, there are 2 problems using this construct:
1) The databaseIconTypes NSDictionary still contains the icons that are removed from the databaseIcons NSArray, and thus contains more icons.
2) A NSDictionary cannot be sorted in any way and the ordering of items might be different from the databaseIcons NSArray. 
# Proposed fix

I have implemented a fix in two steps:
1) Sorting the databaseIcons NSArray based on the MPIconType ID
2) Adding a databaseIconTypes NSArray containing the MPIconType ID and is sorted in the same ordering.

Both databaseIcons and databaseIconTypes now contain the same set of icons and are sorted in the same ordering. Next to fixing the dodgy icon selection, this also changes the ordering of the icons on the UI (because the icons are now ordered by increasing MPIconType ID.

This is my first contribution to a Objective C program, so please be critical in reviewing my fix :-)

Kind regards,

Dennis Bolio.
