### PR TITLE
 Make autotype work in more situations

### DIFF
--- a/MacPass/MPAutotypeDaemon.m
+++ b/MacPass/MPAutotypeDaemon.m
@@ -27,7 +27,7 @@ NSString *const kMPWindowTitleKey = @"windowTitle";
 NSString *const kMPApplciationNameKey = @"applicationName";
 
 /*
- Enabel to activate autotype
+ Enable to activate autotype
 #define MP_AUTOTYPE
 */
 

--- a/MacPass/MPDocument+Autotype.m
+++ b/MacPass/MPDocument+Autotype.m
@@ -37,8 +37,12 @@
   NSArray *autotypeEntries = [self.root autotypeableChildEntries];
   NSMutableArray *contexts = [[NSMutableArray alloc] initWithCapacity:MAX(1,ceil([autotypeEntries count] / 4.0))];
   for(KPKEntry *entry in autotypeEntries) {
-    /* Test for title */
-    NSRange titleRange = [entry.title rangeOfString:windowTitle options:NSCaseInsensitiveSearch];
+    /* Test for entry title in window title */
+    NSRange titleRange = [windowTitle rangeOfString:entry.title options:NSCaseInsensitiveSearch];
+    /* Test for window title in entry title */
+    if (titleRange.location == NSNotFound || titleRange.length == 0) {
+      titleRange = [entry.title rangeOfString:windowTitle options:NSCaseInsensitiveSearch];
+    }
     MPAutotypeContext *context;
     if(titleRange.location != NSNotFound && titleRange.length != 0) {
       context = [[MPAutotypeContext alloc] initWithEntry:entry andSequence:entry.autotype.defaultKeystrokeSequence];


### PR DESCRIPTION
 The entry title will first be searched for within the window title. If the
 window title does not contain the entry title, then the window title will be
 searched for within the entry title.
