### PR TITLE
xyz was missing from list of password generation characters

### DIFF
--- a/MacPass/NSString+MPPasswordCreation.m
+++ b/MacPass/NSString+MPPasswordCreation.m
@@ -9,7 +9,7 @@
 #import "NSString+MPPasswordCreation.h"
 #import "NSData+Random.h"
 
-NSString *const kMPLowercaseLetterCharacters = @"abcdefghijklmnopqrstuvw";
+NSString *const kMPLowercaseLetterCharacters = @"abcdefghijklmnopqrstuvwxyz";
 NSString *const kMPNumberCharacters = @"1234567890";
 NSString *const kMPSymbolCharacters = @"!$%&\\|/<>(){}[]=?*'+#-_.:,;";
 


### PR DESCRIPTION
Looks like these three characters weren't included in the list of characters to generate passwords with.
