### PR TITLE
Wait 0.1s between the keydown and keyup event

### DIFF
--- a/MacPass/MPAutotypeCommand.m
+++ b/MacPass/MPAutotypeCommand.m
@@ -196,6 +196,7 @@
   
   /* Send the event */
   CGEventPost(kCGSessionEventTap, pressKey);
+  usleep(100000);
   CGEventPost(kCGSessionEventTap, releaseKey);
   
   CFRelease(pressKey);


### PR DESCRIPTION
I observed an issue where when autotyping into the Steam client the tab
key wouldn't register. Adding a 0.1s delay between the keydown and keyup
events seems to gives the application enough time to register the key
press.
