### PR TITLE
Percent escape strings before creating URLs

### DIFF
--- a/MacPass/MPEntryViewController.m
+++ b/MacPass/MPEntryViewController.m
@@ -616,10 +616,10 @@ NSString *const _MPTAbleSecurCellView = @"PasswordCell";
 - (void)openURL:(id)sender {
   KPKEntry *selectedEntry = [self _clickedOrSelectedEntry];
   if(selectedEntry && [selectedEntry.url length] > 0) {
-    NSURL *webURL = [NSURL URLWithString:selectedEntry.url];
+    NSURL *webURL = [NSURL URLWithString:[selectedEntry.url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
     NSString *scheme = [webURL scheme];
     if(!scheme) {
-      webURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@", selectedEntry.url]];
+      webURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@", [selectedEntry.url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
     }
     [[NSWorkspace sharedWorkspace] openURL:webURL];
     /* Add custom browser support */


### PR DESCRIPTION
URLWithString will return nil if the string contains invalid URL
characters (such as spaces). Percent escape the string before attempting
to create an NSURL using it.
