### PR TITLE
Fixed overlay icon colour on Yosemite

### DIFF
--- a/MacPass/MPOverlayWindowController.m
+++ b/MacPass/MPOverlayWindowController.m
@@ -47,7 +47,7 @@
   [self.window setOpaque:NO];
   [self.window setHasShadow:NO];
   [[self.textField cell] setBackgroundStyle:NSBackgroundStyleLowered];
-  [[self.imageView cell] setBackgroundStyle:NSBackgroundStyleLowered];
+  [[self.imageView cell] setBackgroundStyle:NSBackgroundStyleDark];
   [[self.imageView cell] setImageAlignment:NSImageAlignCenter];
 }
 


### PR DESCRIPTION
The colour of the image was staying black on Yosemite. Before merging could you make sure that it still looks as expected on Mavericks?
