### PR TITLE
Update ContextBar.strings

### DIFF
--- a/MacPass/de.lproj/ContextBar.strings
+++ b/MacPass/de.lproj/ContextBar.strings
@@ -38,7 +38,7 @@
 "ewQ-8F-e1E.title" = "Historie verlassen";
 
 /* Class = "NSButtonCell"; title = "Notes"; ObjectID = "iDN-2E-hwt"; */
-"iDN-2E-hwt.title" = "Notizten";
+"iDN-2E-hwt.title" = "Notizen";
 
 /* Class = "NSButtonCell"; title = "Username"; ObjectID = "jfQ-Jh-2gl"; */
 "jfQ-Jh-2gl.title" = "Benutzername";


### PR DESCRIPTION
Corrected «Notitzten» to «Notizen»