### PR TITLE
Update AutotypeBuilderView.strings

### DIFF
--- a/MacPass/de.lproj/AutotypeBuilderView.strings
+++ b/MacPass/de.lproj/AutotypeBuilderView.strings
@@ -1,9 +1,8 @@
 /* Class = "NSTextFieldCell"; title = "Autotype Sequence"; ObjectID = "8ny-Qk-Jvo"; */
-"8ny-Qk-Jvo.title" = "Auto-Type-Sequenz";
+"8ny-Qk-Jvo.title" = "Autotype-Sequenz";
 
 /* Class = "NSButtonCell"; title = "Set Autotype Sequence"; ObjectID = "aOD-Ih-Sft"; */
-"aOD-Ih-Sft.title" = "Auto-Type-Sequenz festlegen";
+"aOD-Ih-Sft.title" = "Autotype-Sequenz festlegen";
 
 /* Class = "NSTextFieldCell"; title = "Available Commands and Placeholders"; ObjectID = "lug-97-H9D"; */
 "lug-97-H9D.title" = "Verfügbare Kommandos und Platzhalter";
-


### PR DESCRIPTION
Consistency in Localisation, «Auto-Type» now called «Autotype» like in English Translation