### PR TITLE
Update AutotypeCandidateSelectionView.strings

### DIFF
--- a/MacPass/de.lproj/AutotypeCandidateSelectionView.strings
+++ b/MacPass/de.lproj/AutotypeCandidateSelectionView.strings
@@ -1,5 +1,5 @@
 /* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "60p-7v-Nje"; */
-"60p-7v-Nje.title" = "Abbrehen";
+"60p-7v-Nje.title" = "Abbrechen";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PKW-gr-yqN"; */
 "PKW-gr-yqN.title" = "Text Cell";
@@ -11,5 +11,5 @@
 "gcf-gb-ZsF.title" = "Es gibt mehrere Treffer für den aktuellen Fenstertitel. Bitte wählen Sie den Eintrag aus der Liste aus, welcher verwendet werden soll.";
 
 /* Class = "NSButtonCell"; title = "Perform Autotype"; ObjectID = "w7H-hx-CUF"; */
-"w7H-hx-CUF.title" = "Auto-Type ausführen.";
+"w7H-hx-CUF.title" = "Autotype ausführen.";
 


### PR DESCRIPTION
Consistency in Localisation, «Auto-Type» now called «Autotype» like in English Translation.
Typo «Abbrechen» corrected.