### PR TITLE
Update DuplicateEntryOptionsWindow.strings

### DIFF
--- a/MacPass/de.lproj/DuplicateEntryOptionsWindow.strings
+++ b/MacPass/de.lproj/DuplicateEntryOptionsWindow.strings
@@ -11,7 +11,7 @@
 "dXl-KS-4rE.title" = "Historie duplizieren";
 
 /* Class = "NSButtonCell"; title = "Reference password instead of copying it"; ObjectID = "daA-QV-CDq"; */
-"daA-QV-CDq.title" = "Password als Referenz statt Kopie";
+"daA-QV-CDq.title" = "Passwort als Referenz statt Kopie";
 
 /* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "x6e-bE-Y6R"; */
 "x6e-bE-Y6R.title" = "Abbrechen";


### PR DESCRIPTION
German «Passwort» instead of english «Password»