### PR TITLE
Fixes build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mstarke/MacPass.svg?branch=continuous)](https://travis-ci.org/mstarke/MacPass)
+[![Build Status](https://travis-ci.org/MacPass/MacPass.svg?branch=continuous)](https://travis-ci.org/MacPass/MacPass)
 
 # MacPass
 


### PR DESCRIPTION
Build status badge used to point at a wrong (old?) URL. Fixed by changing URL to MacPass/MacPass.