### PR TITLE
Automaticly select first row in MPAutotypeCandidateSelectionViewController

### DIFF
--- a/MacPass/MPAutotypeCandidateSelectionViewController.m
+++ b/MacPass/MPAutotypeCandidateSelectionViewController.m
@@ -42,6 +42,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.selectAutotypeContextButton.enabled = NO;
+  [self.contextTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
 }
 
 #pragma mark NSTableViewDataSource


### PR DESCRIPTION
To engage people to use the keyboard (especially the arrow keys) in the MPAutotypeCandidateSelectionViewController, I'm suggesting to select the first row in the `viewDidLoad` method. The highlighted item increases the perception as a native macOS Table View.

This corresponds with the behaviour in the MPEntryViewController, where the first entry is selected after switching folders.