### PR TITLE
Changed "Sauvegarder" => "Enregistrer"

### DIFF
--- a/MacPass/fr.lproj/Localizable.strings
+++ b/MacPass/fr.lproj/Localizable.strings
@@ -73,8 +73,8 @@
 "NONE" = "NONE";
 "NOTES" = "Notes";
 "PASSWORD" = "Mot de passe";
-"SAVE" = "Sauvegarder";
-"SAVE_WITH_DOTS" = "Sauvegarder…";
+"SAVE" = "Enregistrer";
+"SAVE_WITH_DOTS" = "Enregistrer…";
 "SEARCH" = "Rechercher";
 "TITLE" = "Titre";
 "URL" = "URL";


### PR DESCRIPTION
"Save" in this context, translated to French is "Enregistrer", not "Sauvegarder" (which means "to backup").