### PR TITLE
Make keyfile selection window modal

### DIFF
--- a/MacPass/MPPathControl.m
+++ b/MacPass/MPPathControl.m
@@ -39,11 +39,10 @@
   if([self.delegate respondsToSelector:@selector(pathControl:willDisplayOpenPanel:)]) {
     [self.delegate pathControl:self willDisplayOpenPanel:panel];
   }
-  [panel beginWithCompletionHandler:^(NSModalResponse result) {
-    if(result == NSModalResponseOK) {
-      self.URL = panel.URLs.firstObject;
-    }
-  }];
+  NSModalResponse result = [panel runModal];
+  if(result == NSModalResponseOK) {
+    self.URL = panel.URLs.firstObject;
+  }
 }
 
 - (void)pathControl:(NSPathControl *)pathControl willPopUpMenu:(NSMenu *)menu {


### PR DESCRIPTION
If we don't use the modal view, the user can put the file selection window to background, click 'Choose...' and open additional windows.

This can become confusing and the additional windows can stay there hanging through the app's lifecycle. Moreover, if we choose 'Choose...' from the drop down menu, after selecting a key file, the dialog displayed is currently modal, inline with this commit.