### PR TITLE
Updated german localization

### DIFF
--- a/MacPass/de.lproj/GeneralSettings.strings
+++ b/MacPass/de.lproj/GeneralSettings.strings
@@ -56,7 +56,7 @@
 "806.title" = "Sperren nach Inaktivität";
 
 /* Class = "NSTextFieldCell"; title = "Close and open all documents for changes to take effect"; ObjectID = "3Bo-Ml-1KB"; */
-"3Bo-Ml-1KB.title" = "Zum Anwenden der Änderungen, muss das Dokument neu geöffnet werden.";
+"3Bo-Ml-1KB.title" = "Die Änderungen werden erst für Dokumente wirksam, welche geschlossen und erneut geöffnet werden.";
 
 /* Class = "NSBox"; title = "File Handling"; ObjectID = "888"; */
 "888.title" = "Dateibehandlung";

--- a/MacPass/de.lproj/GeneralSettings.strings
+++ b/MacPass/de.lproj/GeneralSettings.strings
@@ -46,11 +46,17 @@
 /* Class = "NSButtonCell"; title = "Lock after sleep"; ObjectID = "631"; */
 "631.title" = "Datenbank im Ruhezustand sperren";
 
+/* Class = "NSButtonCell"; title = "Enable Autosave"; ObjectID = ""wG7-bi-2fi""; */
+"wG7-bi-2fi.title" = "Automatisches Speichern aktivieren";
+
 /* Class = "NSMenuItem"; title = "Never"; ObjectID = "804"; */
 "804.title" = "Nie";
 
 /* Class = "NSTextFieldCell"; title = "Lock while idle"; ObjectID = "806"; */
 "806.title" = "Sperren nach Inaktivität";
+
+/* Class = "NSTextFieldCell"; title = "Close and open all documents for changes to take effect"; ObjectID = "3Bo-Ml-1KB"; */
+"3Bo-Ml-1KB.title" = "Zum Anwenden der Änderungen, muss das Dokument neu geöffnet werden.";
 
 /* Class = "NSBox"; title = "File Handling"; ObjectID = "888"; */
 "888.title" = "Dateibehandlung";


### PR DESCRIPTION
Add in GeneralSettings.strings "Enable Autosave" and "Close and open all documents for changes to take effect" in German.

Hope that's in the right format, this two points in general settings are not localized at the moment.

Best regards,
Jesse