### PR TITLE
Fix localized string ambiguous with word allow/disallow

### DIFF
--- a/MacPass/MPPluginRepository.m
+++ b/MacPass/MPPluginRepository.m
@@ -175,8 +175,8 @@ NSString *const MPPluginRepositoryDidUpdateAvailablePluginsNotification = @"com.
     alert.informativeText = NSLocalizedString(@"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT", @"Informative text displayed on the alert that shows up when MacPass asks for permssion to download the plugin repository JSON file");
     alert.messageText = NSLocalizedString(@"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE", @"Message displayed on the alert that asks for permission to download the plugin repository JSON file");
     alert.showsSuppressionButton = YES;
-    [alert addButtonWithTitle:NSLocalizedString(@"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD", @"Disallow the download of the plugin repository file")];
     [alert addButtonWithTitle:NSLocalizedString(@"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD", @"Allow the download of the plugin repository file")];
+    [alert addButtonWithTitle:NSLocalizedString(@"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD", @"Disallow the download of the plugin repository file")];
     NSModalResponse repsonse = [alert runModal];
     BOOL allow = (repsonse == NSAlertFirstButtonReturn);
     [NSUserDefaults.standardUserDefaults setBool:allow forKey:kMPSettingsKeyAllowRemoteFetchOfPluginRepository];

--- a/MacPass/de.lproj/Localizable.strings
+++ b/MacPass/de.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "ADD_TREMPLATE_ENTRY" = "Vorgabeeintrag erstellen";
 
 /* Allow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Keine Daten herunterladen.";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Aktualisiere Daten online.";
 
 /* Informative text displayed on the alert that shows up when MacPass asks for permssion to download the plugin repository JSON file */
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT" = "Das Verzeichnis ist auf https://macpassapp.org hinterlegt. MacPass verbindet lädt die Defintionen herunter um sicher zu stellen, dass alle Daten auf dem neusten Stand sind.";
@@ -47,7 +47,7 @@
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass möchte das Pluginverzeichnis aktualisieren.";
 
 /* Disallow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Aktualisiere Daten online.";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Keine Daten herunterladen.";
 
 /* Button in dialog to leave autotype disabled and continiue! */
 "ALERT_AUTOTYPE_MISSING_ACCESSIBILTY_PERMISSIONS_BUTTON_OK" = "Autotype deaktiviert lassen.";

--- a/MacPass/en.lproj/Localizable.strings
+++ b/MacPass/en.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "ADD_TREMPLATE_ENTRY" = "Create Template Entry";
 
 /* Allow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Do not update defintions";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Update definitions online";
 
 /* Informative text displayed on the alert that shows up when MacPass asks for permssion to download the plugin repository JSON file */
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT" = "The plugin defintions are hosted online at https://macpassapp.org. MacPass would like to download those files to ensure the data is up to date.";
@@ -47,7 +47,7 @@
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass would like to check for updates of plugin defintions online";
 
 /* Disallow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Update definitions online";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Do not update defintions";
 
 /* Button in dialog to leave autotype disabled and continiue! */
 "ALERT_AUTOTYPE_MISSING_ACCESSIBILTY_PERMISSIONS_BUTTON_OK" = "Keep Autotype disabled.";

--- a/MacPass/en.lproj/Localizable.strings
+++ b/MacPass/en.lproj/Localizable.strings
@@ -44,7 +44,7 @@
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT" = "The plugin defintions are hosted online at https://macpassapp.org. MacPass would like to download those files to ensure the data is up to date.";
 
 /* Message displayed on the alert that askf for permission to download the plugin repository JSON file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass would like to check for updates of plugin defintions online";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass would like to check for updates of plugin definitions online";
 
 /* Disallow the download of the plugin repository file */
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Do not update defintions";

--- a/MacPass/es.lproj/Localizable.strings
+++ b/MacPass/es.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "ADD_TREMPLATE_ENTRY" = "Crear Plantilla de Entrada";
 
 /* Allow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "No actualizar definiciones";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Actualizar las definiciones online";
 
 /* Informative text displayed on the alert that shows up when MacPass asks for permssion to download the plugin repository JSON file */
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT" = "Las definiciones de los plugin están almacenadas online en https://macpassapp.org. A MacPass le gustaría descargar los archivos para asegurar que los datos están actualizados";
@@ -47,7 +47,7 @@
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "A MacPass le gustaría comprobar las actualizaciones de las definiciones de los plugin online";
 
 /* Disallow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Actualizar las definiciones online";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "No actualizar definiciones";
 
 /* Button in dialog to leave autotype disabled and continiue! */
 "ALERT_AUTOTYPE_MISSING_ACCESSIBILTY_PERMISSIONS_BUTTON_OK" = "Mantener Autotecleo deshabilitado.";


### PR DESCRIPTION
Fix the correct meaning of the NSLocalizedString constant for the alert button titles