### PR TITLE
Update all missing french localization

### DIFF
--- a/MacPass.xcodeproj/project.pbxproj
+++ b/MacPass.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		3C0CDECE21CFEDD200B2A10B /* NSTextView+MPTouchBarExtension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSTextView+MPTouchBarExtension.m"; sourceTree = "<group>"; };
 		3C0CDED721D28BF700B2A10B /* MPTouchBarButtonCreator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPTouchBarButtonCreator.m; sourceTree = "<group>"; };
 		3C0CDED921D28C0E00B2A10B /* MPTouchBarButtonCreator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPTouchBarButtonCreator.h; sourceTree = "<group>"; };
+		43B7080F240978E500F68426 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AutotypeDoctorReportViewController.strings; sourceTree = "<group>"; };
 		4825CC811C414D57003E37E9 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/DatabaseSettingsWindow.strings; sourceTree = "<group>"; };
 		4825CC821C414D57003E37E9 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/PasswordEditWindow.strings; sourceTree = "<group>"; };
 		4825CC831C414D57003E37E9 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/WelcomeView.strings; sourceTree = "<group>"; };
@@ -2634,6 +2635,7 @@
 				71FF7A27230FEF6B002F488F /* it */,
 				ABE8662F2316617500201125 /* zh-Hans */,
 				78C093DB236A18560008577C /* ru */,
+				43B7080F240978E500F68426 /* fr */,
 			);
 			name = AutotypeDoctorReportViewController.xib;
 			sourceTree = "<group>";

--- a/MacPass/fr.lproj/AutotypeBuilderView.strings
+++ b/MacPass/fr.lproj/AutotypeBuilderView.strings
@@ -1,3 +1,9 @@
+/* Class = "NSTextFieldCell"; title = "Autotype Sequence"; ObjectID = "8ny-Qk-Jvo"; */
+"8ny-Qk-Jvo.title" = "Séquence de saisie automatique";
+
+/* Class = "NSButtonCell"; title = "Set Autotype Sequence"; ObjectID = "aOD-Ih-Sft"; */
+"aOD-Ih-Sft.title" = "Définir une séquence de saisie automatique";
+
 /* Class = "NSTextFieldCell"; title = "Available Commands and Placeholders"; ObjectID = "lug-97-H9D"; */
 "lug-97-H9D.title" = "Commandes et emplacements disponibles";
 

--- a/MacPass/fr.lproj/AutotypeCandidateSelectionView.strings
+++ b/MacPass/fr.lproj/AutotypeCandidateSelectionView.strings
@@ -2,7 +2,7 @@
 "60p-7v-Nje.title" = "Annuler";
 
 /* Class = "NSTextFieldCell"; title = "There are multiple matches for the current window. Please select which match should be used."; ObjectID = "gcf-gb-ZsF"; */
-"gcf-gb-ZsF.title" = "Il existe plusieurs possibilités pour la fenêtre courante. Sélectionner celui qui doit être utilisé";
+"gcf-gb-ZsF.title" = "Il existe plusieurs possibilités pour la fenêtre courante. Veuillez sélectionner le résultat qui doit être utilisé.";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PKW-gr-yqN"; */
 "PKW-gr-yqN.title" = "Libellé de la cellule";

--- a/MacPass/fr.lproj/AutotypeDoctorReportViewController.strings
+++ b/MacPass/fr.lproj/AutotypeDoctorReportViewController.strings
@@ -1,0 +1,24 @@
+/* Class = "NSButtonCell"; title = "Request Permissions…"; ObjectID = "1Nx-Cg-TCn"; */
+"1Nx-Cg-TCn.title" = "Demande de permissions...";
+
+/* Class = "NSTextFieldCell"; title = "MacPass will send key press events to the system when Autotype or Global Autotype is executed. Since macOS 10.14 Mojave this is only possible, if Accessibility permissions are granted to the application."; ObjectID = "6GI-KJ-Xue"; */
+"6GI-KJ-Xue.title" = "MacPass va envoyer des évènement de touches pressées au système lorsque la saisie automatique est déclenchée. Depuis macOS 10.14 (Mojave), cela est possible uniquement si les permissions d'Accessibilité sont accordées à l'application.";
+
+/* Class = "NSTextFieldCell"; title = "MacPass will read every window title when Global Autotype is executed to find a match. Since macOS 10.15 Catalina it is not possible to read any window title, if the user has not granted permissions to record the screen. If you are running macOS 10.15 or higher, MacPass will check if it can read every window title of currently visible windows. This test will not read the actual title. The titles aren't stored or processed in any way."; ObjectID = "7of-1z-Nfk"; */
+"7of-1z-Nfk.title" = "MacPass va lire tout les titres de fenêtres lorsque la saisie automatique globale est déclenchée pour trouver un résultat correspondant. Depuis macOS 10.15 (Catalina), il est impossible de lire les titres de fenêtres si l'utilisateur n'a pas accordé la permission de capture d'écran. Si vous utilisé(e) macOS 10.15 ou supérieur, MacPass va essayer de lire tout les titres de fenêtres actuellement visibles. Ce test ne va pas lire le contenu actuel des titres. Les titres ne sont ni stockés ni utilisés à d'autre fin.";
+
+/* Class = "NSButtonCell"; title = "Open Accessibilty Preferences…"; ObjectID = "8m1-vs-pd5"; */
+"8m1-vs-pd5.title" = "Ouvrir les préférences d'accessibilité";
+
+/* Class = "NSTextFieldCell"; title = "Screen Recording"; ObjectID = "9gr-mz-2I4"; */
+"9gr-mz-2I4.title" = "Enregistrement d'écran";
+
+/* Class = "NSTextFieldCell"; title = "Accessibility"; ObjectID = "aIL-8W-63g"; */
+"aIL-8W-63g.title" = "Accessibilité";
+
+/* Class = "NSButtonCell"; title = "Open Screen Recording Preferences…"; ObjectID = "lgB-Ys-L9R"; */
+"lgB-Ys-L9R.title" = "Ouvrir les préférences concernant l'enregistrement d'écran...";
+
+/* Class = "NSTextFieldCell"; title = "To request Screen Recording permissions, MacPass will try to capture a 1 by 1 Pixel sized screenshot of the top left part of your screen. The data is not stored nor processed in any way."; ObjectID = "Mhg-rd-1hK"; */
+"Mhg-rd-1hK.title" = "Pour demander la permission d'enregistrement d'écran, MacPass va essayer de capturer une image de 1 par 1 pixel de la partie en haut à gauche de votre écran. Cette image n'est ni stockée ni utilisée à d'autre fin.";
+

--- a/MacPass/fr.lproj/ContextBar.strings
+++ b/MacPass/fr.lproj/ContextBar.strings
@@ -14,10 +14,10 @@
 "92o-gN-Psj.title" = "URL";
 
 /* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "CFk-71-NYQ"; */
-"CFk-71-NYQ.title" = "Item 3";
+"CFk-71-NYQ.title" = "2ème élément";
 
 /* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "cpr-p6-YAY"; */
-"cpr-p6-YAY.title" = "Item 2";
+"cpr-p6-YAY.title" = "3ème élément";
 
 /* Class = "NSTextFieldCell"; title = "History"; ObjectID = "ER3-Ic-v0N"; */
 "ER3-Ic-v0N.title" = "Historique";
@@ -32,7 +32,7 @@
 "jfQ-Jh-2gl.title" = "Nom d'utilisateur";
 
 /* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "LRm-iZ-XrA"; */
-"LRm-iZ-XrA.title" = "Item 1";
+"LRm-iZ-XrA.title" = "1er élément";
 
 /* Class = "NSTabViewItem"; label = "Trash"; ObjectID = "na6-h9-r9q"; */
 "na6-h9-r9q.label" = "Corbeille";
@@ -48,6 +48,9 @@
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "wC4-fF-dLW"; */
 "wC4-fF-dLW.title" = "Autres vues";
+
+/* Class = "NSButtonCell"; title = "Everywhere"; ObjectID = "WMK-bb-ESj"; */
+"WMK-bb-ESj.title" = "Partout";
 
 /* Class = "NSTabViewItem"; label = "History"; ObjectID = "z4I-cp-nhf"; */
 "z4I-cp-nhf.label" = "Historique";

--- a/MacPass/fr.lproj/DatabaseSettingsWindow.strings
+++ b/MacPass/fr.lproj/DatabaseSettingsWindow.strings
@@ -10,6 +10,9 @@
 /* Class = "NSTextFieldCell"; title = "Enforce key change"; ObjectID = "5QH-N1-FHK"; */
 "5QH-N1-FHK.title" = "Forcer le changement de clé";
 
+/* Class = "NSTabViewItem"; label = "Argon2"; ObjectID = "6qB-sH-9FI"; */
+"6qB-sH-9FI.label" = "Argon2";
+
 /* Class = "NSTextFieldCell"; title = "Database name:"; ObjectID = "190"; */
 "190.title" = "Nom de la base de données :";
 
@@ -35,7 +38,7 @@
 "536.title" = "Activer la corbeille";
 
 /* Class = "NSTextFieldCell"; title = "Maximum items in history:"; ObjectID = "558"; */
-"558.title" = "Nombre maximum d'éléments :";
+"558.title" = "Nombre maximum d'éléments dans l'historique :";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "680"; */
 "680.title" = "Autres vues";
@@ -44,7 +47,7 @@
 "957.title" = "Annuler";
 
 /* Class = "NSTextFieldCell"; title = "Maximum history size:"; ObjectID = "1269"; */
-"1269.title" = "Taille maximum :";
+"1269.title" = "Taille maximum de l'historique :";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1396"; */
 "1396.title" = "Autres vues";
@@ -76,6 +79,9 @@
 /* Class = "NSButtonCell"; title = "Recommend key change"; ObjectID = "CtU-Eq-dgy"; */
 "CtU-Eq-dgy.title" = "Recommander le changement de la clé tous les :";
 
+/* Class = "NSTabViewItem"; label = "Aes"; ObjectID = "ft1-pl-lpO"; */
+"ft1-pl-lpO.label" = "Aes";
+
 /* Class = "NSTextFieldCell"; title = "Algorithm"; ObjectID = "GVd-KH-pHc"; */
 "GVd-KH-pHc.title" = "Algorithme";
 
@@ -86,7 +92,7 @@
 "iRY-If-Kwn.title" = "Mémoire";
 
 /* Class = "NSTextFieldCell"; title = "Recyclebin Group:"; ObjectID = "kI5-Kp-byE"; */
-"kI5-Kp-byE.title" = "Groupe corbeille";
+"kI5-Kp-byE.title" = "Groupe corbeille :";
 
 /* Class = "NSButtonCell"; title = "Force key change once after unlocking"; ObjectID = "pA1-aL-KjT"; */
 "pA1-aL-KjT.title" = "Forcer le changement de clé une fois déverrouillé";
@@ -99,6 +105,9 @@
 
 /* Class = "NSTextFieldCell"; title = "VersionInfo"; ObjectID = "Ush-4r-A1A"; */
 "Ush-4r-A1A.title" = "Information de version";
+
+/* Class = "NSTextFieldCell"; title = "Rounds"; ObjectID = "uUQ-9s-M5E"; */
+"uUQ-9s-M5E.title" = "Rounds";
 
 /* Class = "NSTextFieldCell"; title = "Recommend key change"; ObjectID = "Xib-Fn-sqx"; */
 "Xib-Fn-sqx.title" = "Recommander le changement de clé";

--- a/MacPass/fr.lproj/EntryInspectorView.strings
+++ b/MacPass/fr.lproj/EntryInspectorView.strings
@@ -100,6 +100,9 @@
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "sNS-o1-pD7"; */
 "sNS-o1-pD7.title" = "Autres vues";
 
+/* Class = "NSTextFieldCell"; title = "UUID"; ObjectID = "vTq-N1-5oa"; */
+"vTq-N1-5oa.title" = "UUID";
+
 /* Class = "NSButtonCell"; title = "Show Plugin Data"; ObjectID = "X9y-K7-lix"; */
 "X9y-K7-lix.title" = "Afficher les données du plugin";
 

--- a/MacPass/fr.lproj/GeneralPreferences.strings
+++ b/MacPass/fr.lproj/GeneralPreferences.strings
@@ -32,16 +32,16 @@
 "531.title" = "Ouvrir la dernière base de données au lancement";
 
 /* Class = "NSMenu"; title = "LockTimes"; ObjectID = "586"; */
-"586.title" = "Verrouillage";
+"586.title" = "Temps de verrouillage";
 
 /* Class = "NSMenuItem"; title = "for 1 Minute"; ObjectID = "588"; */
-"588.title" = "pour 1 minute";
+"588.title" = "pendant 1 minute";
 
 /* Class = "NSMenuItem"; title = "for 5 Minutes"; ObjectID = "589"; */
-"589.title" = "pour 5 minutes";
+"589.title" = "pendant 5 minutes";
 
 /* Class = "NSMenuItem"; title = "for 15 Minutes"; ObjectID = "603"; */
-"603.title" = "pour 15 minutes";
+"603.title" = "pendant 15 minutes";
 
 /* Class = "NSButtonCell"; title = "Lock after sleep"; ObjectID = "631"; */
 "631.title" = "Verrouillage après sommeil";
@@ -56,16 +56,25 @@
 "888.title" = "Gestion des fichiers";
 
 /* Class = "NSTextFieldCell"; title = "Enabling this compromises security. If enabled, your preferences will contain mappings from database to keyfile. Key locations for databases without a password will not be saved."; ObjectID = "ACh-7H-42N"; */
-"ACh-7H-42N.title" = "Cocher cette case compromet la sécurité. Si activé, les associations base de données / fichiers clé seront enregistrées. La localisation des clés pour les bases de données sans mot de passe n'est pas sauvegardée.";
+"ACh-7H-42N.title" = "Cocher cette case compromet la sécurité. Si activé, vos préférences contiendront les associations base de données / fichier clé. L'emplacement des clés pour les bases de données sans mot de passe ne seront pas sauvegardés.";
 
 /* Class = "NSButtonCell"; title = "Lock after log out"; ObjectID = "Dzn-9R-JjE"; */
 "Dzn-9R-JjE.title" = "Verrouiller après déconnexion";
+
+/* Class = "NSButtonCell"; title = "Prevent Universal Clipboard support"; ObjectID = "fNy-mS-phi"; */
+"fNy-mS-phi.title" = "Désactiver le support de presse-papier universel";
+
+/* Class = "NSTextFieldCell"; title = "Disabling this compromises security. If enabled, anything copied to the Clipboard in MacPass will be available on your connected iOS devices. You should clear the clipboard on those devices manually."; ObjectID = "JGX-Tp-KJk"; */
+"JGX-Tp-KJk.title" = "Désactiver ceci compromet la sécurité. Si activé, tout ce qui est copié dans le presse-papiers depuis MacPass sera accessible depuis tout les appareils iOS connectés. Vous devrez effacer le presse-papiers sur ces appareils manuellement.";
+
+/* Class = "NSButtonCell"; title = "Lock after screen sleep"; ObjectID = "l3t-og-mJd"; */
+"l3t-og-mJd.title" = "Verrouiller après l'activation de l'économiseur d'écran";
 
 /* Class = "NSTextFieldCell"; title = "If file changes:"; ObjectID = "QrK-hM-Xt1"; */
 "QrK-hM-Xt1.title" = "Si modifications du fichier :";
 
 /* Class = "NSButtonCell"; title = "Remember Keyfile for Databases"; ObjectID = "r6q-He-nYU"; */
-"r6q-He-nYU.title" = "Enregistrer la localisation des fichiers clé";
+"r6q-He-nYU.title" = "Se souvenir des fichiers clé pour les bases de données";
 
 /* Class = "NSButtonCell"; title = "Enable Autosave"; ObjectID = "wG7-bi-2fi"; */
 "wG7-bi-2fi.title" = "Activer l'enregistrement automatique";

--- a/MacPass/fr.lproj/InfoPlist.strings
+++ b/MacPass/fr.lproj/InfoPlist.strings
@@ -1,3 +1,6 @@
+/* Bundle name */
+"CFBundleName" = "MacPass";
+
 /* (No Comment) */
 "KDB Database" = "Base de données KDB";
 
@@ -6,4 +9,28 @@
 
 /* (No Comment) */
 "MacPass Plugin" = "Plugin MacPass";
+
+/* Privacy - AppleEvents Sending Usage Description */
+"NSAppleEventsUsageDescription" = "MacPass pourrait utiliser AppleEvents pour permettre la fonctionnalité de saisie automatique";
+
+/* Privacy - Desktop Folder Usage Description */
+"NSDesktopFolderUsageDescription" = "MacPass accède au Bureau pour charger et sauvegarder vos bases de données et/ou les fichiers clé à cet emplacement";
+
+/* Privacy - Documents Folder Usage Description */
+"NSDocumentsFolderUsageDescription" = "MacPass accède au dossier Documents pour charger et sauvegarder vos bases de données et/ou les fichiers clé à cet emplacement";
+
+/* Privacy - Downloads Folder Usage Description */
+"NSDownloadsFolderUsageDescription" = "MacPass accède au dossier Téléchargements pour charger et sauvegarder vos bases de données et/ou les fichiers clé à cet emplacement";
+
+/* (No Comment) */
+"NSHumanReadableCopyright" = "Copyright ©2012-2020 HicknHack Software GmbH. Tous droits réservés.";
+
+/* Privacy - Network Volumes Usage Description */
+"NSNetworkVolumesUsageDescription" = "MacPass nécessite l'accès aux volumes réseau pour charger et sauvegarder vos bases de données et/ou fichiers clé à cet endroit";
+
+/* Privacy - Removable Volumes Usage Description */
+"NSRemovableVolumesUsageDescription" = "MacPass nécessite l'accès aux volumes amovibles pour charger et sauvegarder vos bases de données et/ou fichiers clé à cet endroit";
+
+/* (No Comment) */
+"XML" = "XML";
 

--- a/MacPass/fr.lproj/IntegrationPreferences.strings
+++ b/MacPass/fr.lproj/IntegrationPreferences.strings
@@ -1,22 +1,22 @@
 /* Class = "NSButtonCell"; title = "Enable global Autotype"; ObjectID = "1qb-Rd-jYu"; */
-"1qb-Rd-jYu.title" = "Activer la saisie automatique";
+"1qb-Rd-jYu.title" = "Activer la saisie automatique globale";
 
 /* Class = "NSTextFieldCell"; title = "Shortcut"; ObjectID = "6oN-CH-T0O"; */
 "6oN-CH-T0O.title" = "Raccourci";
 
 /* Class = "NSButtonCell"; title = "Include Entry URL Host for matches"; ObjectID = "B1D-j9-L8x"; */
-"B1D-j9-L8x.title" = "Inclure l'hôte pour la correspondance";
+"B1D-j9-L8x.title" = "Inclure l'URL hôte de l'entrée pour la correspondance";
 
 /* Class = "NSButtonCell"; title = "Enable Quicklook Preview"; ObjectID = "ERs-ct-Eyx"; */
 "ERs-ct-Eyx.title" = "Autoriser la prévisualisation coup d'œil";
 
-/* Class = "NSTextFieldCell"; title = "Autotype is not available, because MacPass is not allowed to control your computer. To enable Autotype, go to the Security and Privacy Preferences and add MacPass to the Accessibilty group. Changes require a restart of MacPass."; ObjectID = "H37-ku-aTc"; */
+/* Class = "NSTextFieldCell"; title = "Autotype might not work properly. Some issues where found that prevent Autotype or Global Autotype to work. Please run the Autotype Doctor to fix those issues."; ObjectID = "H37-ku-aTc"; */
 "H37-ku-aTc.title" = "La saisie automatique n'est pas disponible, car MacPass n'est autorisé à contrôler votre ordinateur. Pour activer la saisie automatique, allez dans les Préférences Système, Sécurité et Confidentialité, et ajoutez MacPass dans les applications autorisées à contrôler votre ordinateur. Ces modifications requièrent un redémarrage de MacPass.";
 
 /* Class = "NSTextFieldCell"; title = "Shortcut is missing Key"; ObjectID = "Lxp-wI-yQy"; */
 "Lxp-wI-yQy.title" = "Aucune touche n'est affectée au raccourci";
 
-/* Class = "NSButtonCell"; title = "Open Preferences…"; ObjectID = "NP0-R3-m6n"; */
+/* Class = "NSButtonCell"; title = "Run Autotype Doctor…"; ObjectID = "NP0-R3-m6n"; */
 "NP0-R3-m6n.title" = "Ouvrir les Préférences…";
 
 /* Class = "NSBox"; title = "Autotype"; ObjectID = "P9N-HM-wER"; */
@@ -29,7 +29,7 @@
 "QRy-CY-ENC.title" = "Si activé, chaque commande {CONTROL} sera envoyée comme ⌘. Ne décochez que si vous êtes sûr d'en avoir besoin.";
 
 /* Class = "NSButtonCell"; title = "Include Entry Tags for matches"; ObjectID = "rbu-G7-MT8"; */
-"rbu-G7-MT8.title" = "Inclure les Tags pour la correspondance";
+"rbu-G7-MT8.title" = "Inclure les tags pour la correspondance";
 
 /* Class = "NSButtonCell"; title = "Include Entry Title for matches"; ObjectID = "tmL-dT-D0G"; */
 "tmL-dT-D0G.title" = "Inclure le titre pour la correspondance";

--- a/MacPass/fr.lproj/Localizable.strings
+++ b/MacPass/fr.lproj/Localizable.strings
@@ -1,3 +1,9 @@
+/* Count of characters remaining in pickchars dialog */
+"%ld_CHARACTERS_TO_PICK_REMAINING" = "%ld caractères restants à choisir";
+
+/* Display format for days. Should contain a long decimal placeholder! */
+"%ld_DAYS" = "%ld jours";
+
 /* % days ago */
 "%ld_DAYS_AGO" = "Depuis %ld jours";
 
@@ -14,35 +20,140 @@
 "90_DAYS" = "dans 90 jours";
 
 /* Button label to abort a merge on a file with changed master key! */
-"ABORT_MERGE_KEEP_MINE" = "Annuler la fusion";
+"ABORT_MERGE_KEEP_MINE" = "Annuler la fusion.";
 
 /* Toolbar item with action menu */
 "ACTION" = "Action";
 
+/* Menu item title for adding an hmacotp config attribute */
+"ADD_CUSTOM_ATTRIBUTE_HMACOTP_CONFIG" = "Ajouter une configuration HMACOTP";
+
+/* Menu item title for adding an hmacotp seed attribute */
+"ADD_CUSTOM_ATTRIBUTE_HMACOTP_SEED" = "Ajouter une graine HMACOTP";
+
+/* Menu displayed for adding special custom keys */
+"ADD_CUSTOM_FIELD_CONTEXT_MENU" = "Ajouter un menu de champ personnalisé";
+
 /* Action to add an entry via template */
 "ADD_TREMPLATE_ENTRY" = "Créer un modèle";
+
+/* Allow the download of the plugin repository file */
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Mettre à jour les définitions en ligne";
+
+/* Informative text displayed on the alert that shows up when MacPass asks for permssion to download the plugin repository JSON file */
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT" = "Les définitions de plugins sont hébergés en ligne sur https://macpassapp.org. MacPass aimerait télécharger ces fichiers pour s'assurer que les données sont à jour.";
+
+/* Message displayed on the alert that asks for permission to download the plugin repository JSON file */
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass aimerait vérifier les mises à jour des définitions de plugin en ligne";
+
+/* Disallow the download of the plugin repository file */
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Ne pas mettre à jour les définitions de plugins";
+
+/* Button in dialog to leave plugin ds disabled and continiue! */
+"ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_BUTTON_OK" = "OK";
+
+/* Button in dialog to open plugin preferences pane! */
+"ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_BUTTON_OPEN_PREFERENCES" = "Voir les préférences de plugins...";
+
+/* Informative text of the alert displayed when plugins where disabled due to incompatibilty */
+"ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_INFORMATIVE_TEXT" = "Certains plugins ont été désactivé par ce qu'il ne sont pas compatibles avec cette version de MacPass. Ouvrez le menu des plugins pour plus de détails.";
+
+/* Message text of the alert displayed when plugins where disabled due to incompatibilty */
+"ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_MESSAGE" = "Plugins incompatibles détectés.";
+
+/* Alert informative text when plugins or their settings change and require a restart */
+"ALERT_INFORMATIVE_TEXT_PLUGINS_CHANGED_SUGGEST_RESTART" = "Les changements concernant les plugins ainsi que leur configuration globale ne prendront effet qu'après avoir relance MacPass. Relancer MacPass maintenant?";
+
+/* Alert informative text to ask the user if he really want to uninstall the plugin */
+"ALERT_INFORMATIVE_TEXT_REALLY_UNINSTALL_PLUGIN" = "Le plugin sera déplacé vers la corbeille.";
+
+/* Button in dialog to cancel merge of KDB file changes! */
+"ALERT_MERGE_CANCEL" = "Annuler";
+
+/* Button in dialog to merge KDB changes into file! */
+"ALERT_MERGE_CONTINUE" = "Fusionner les fichiers !";
+
+/* Informative text displayed when merging KDB files */
+"ALERT_MERGE_KDB_FILE_INFO_TEXT" = "Les bases de données KDB ne contiennent pas assez d'informations pour être fusionnées efficacement. Les entrées seront fusionnées et aucune donnée ne sera perdu. Les groupes ne pouvant correspondre que pas leurs noms, cela risque de provoquer des changements non désirés. Les entrées déplacées peuvent se retrouver dans leur groupe précédant, ou les groupes renommés risquent de ne pas être fusionnés. Les entrées supprimées risquent de réapparaître car les informations concernant les objets supprimés ne sont pas stockées. Êtes-vous sûr de vouloir continuer?";
+
+/* Alert message warning user about KDB file merge */
+"ALERT_MERGE_KDB_FILE_MESSAGE" = "Vous allez fusionner une base de données KDB";
+
+/* Alert message text when plugins or their settings change and require a restart */
+"ALERT_MESSAGE_PLUGINS_CHANGED_SUGGEST_RESTART" = "Certaines configurations de plugins ont changé. Veuillez relancer l'application.";
+
+/* Alert message text to ask the user if he really want to uninstall the plugin. Include %@ placeholder for plugin name */
+"ALERT_MESSAGE_TEXT_REALLY_UNINSTALL_PLUGIN_%@" = "Voulez-vous vraiment supprimer le plugin %@ ?";
+
+/* Informative text of the disabled updates alert! */
+"ALERT_UPDATES_DISABLED_INFORMATIVE_TEXT_%@!" = "Les mises à jour concernant la version de %@ sont désactivées !";
+
+/* Message text for disabled updates alert! */
+"ALERT_UPDATES_DISABLED_MESSAGE_TEXT" = "Les mises à jour sont désactivé !";
 
 /* Attachments column title (shows counts)
    Menu item to toggle display of attachment count column in entry table */
 "ATTACHMENTS" = "Fichiers joints";
 
+/* Sucessfully merged external changes */
+"AUTO_MERGE_NOTIFICATION_TEXT" = "La fusion automatique est un succès !";
+
 /* Menu item for automatic trash creation */
 "AUTOCREATE_TRASH_FOLDER" = "Créer automatiquement";
+
+/* Message text in the autotype selection window. Placeholder is %1 - windowTitle */
+"AUTOTYPE_CANDIDATE_SELECTION_WINDOW_MESSAGE_%@" = "Il y a plusieurs éléments correspondants dans la fenêtre courante : %@. Veuillez sélectionner l'élément que vous désirez utiliser.";
+
+/* Window title for the stand-alone password creator window */
+"AUTOTYPE_DOCTOR_RESULTS_WINDOW_TITLE" = "Docteur de saisie automatique";
 
 /* Inherit autotype settings menu item */
 "AUTOTYPE_INHERIT" = "Réglages par défaut";
 
+/* Message displayed to the user to unlock the database to perform global autotype */
+"AUTOTYPE_MESSAGE_UNLOCK_DATABASE" = "Veuillez déverrouiller la base de données pour utiliser la saisie automatique globale";
+
 /* Disable autotype menu item */
 "AUTOTYPE_NO" = "Désactiver la saisie automatique";
 
-/* Notification: Autotype failed, MacPass has no permission to send key strokes */
-"AUTOTYPE_NOTIFICATION_MACPASS_HAS_NO_ACCESSIBILTY_PERMISSIONS" = "Autorisation accessibilité manquant, saisie automatique désactivé.";
+/* Notification: Autotype failed, MacPass has not enough permissions to perform autotype */
+"AUTOTYPE_NOTIFICATION_MACPASS_IS_MISSING_PERMISSIONS" = "MacPass n'a pas toutes les permissions pour effectuer des saisies automatiques.";
+
+/* Notification: Title for autotype feedback */
+"AUTOTYPE_NOTIFICATION_MATCH_TITLE" = "Saisie automatique";
 
 /* Notification: Autotype failed, no documents are open */
 "AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_INFORMATIVE_TEXT" = "Aucun document n'est ouvert";
 
+/* Notification: Title for autotype feedback */
+"AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_TITLE" = "Aucune base de données ouverte !";
+
 /* Noticiation: Autotype failed to find a match for %@ (string placeholder) */
 "AUTOTYPE_NOTIFICATION_NO_MATCH_FOR_%@" = "Pas de correspondance %@ !";
+
+/* Title for autotype feedback on missing permissions */
+"AUTOTYPE_NOTIFICATION_PERMISSIONS_MISSING_TITLE" = "Permissions manquantes";
+
+/* Notification: Autotype found a single match for %@ (string placeholder). */
+"AUTOTYPE_NOTIFICATION_SINGLE_MATCH_FOR_%@" = "Correspondance trouvé pour %@!";
+
+/* Title for the notification when the Autotype operation timed out */
+"AUTOTYPE_NOTIFICATION_TIMED_OUT_TITLE" = "La saisie automatique a expirée !";
+
+/* Status label when no issue were found in accessibilty */
+"AUTOTYPE_STATUS_ACCESSIBILTY_PERMISSIONS_OK" = "MacPass a la permission de contrôler votre ordinateur (Accessibilité)";
+
+/* Status MacPass has no accessibilty permissions */
+"AUTOTYPE_STATUS_NO_ACCESSIBILTY_PERMISSIONS" = "MacPass n'a pas la permission de contrôler votre ordinateur (Accessibilité)";
+
+/* Status MacPass has no screen recording permissions */
+"AUTOTYPE_STATUS_NO_SCREEN_RECORDING_PERMISSIONS" = "MacPass n'a pas la permission d'enregistrer votre écran";
+
+/* Status label when no issue were found in screen recording permissions */
+"AUTOTYPE_STATUS_SCREEN_RECORDING_PERMISSIONS_OK" = "MacPass a la permission d'enregistrer votre écran";
+
+/* Notficication: Autotype timed out */
+"AUTOTYPE_TIMED_OUT" = "Vous avez commencé(e) la saisie automatique il y a trop longtemps. MacPass ne l'a plus effectuée pour éviter des erreurs.";
 
 /* Enable autotype menu item */
 "AUTOTYPE_YES" = "Activer la saisie automatique";
@@ -53,6 +164,9 @@
 /* Menu item in the database outline context menu to change the database name */
 "CHANGE_DATABASE_NAME" = "Modifier le nom de la base de données";
 
+/* Button to postpone the password change */
+"CHANGE_LATER" = "Changer plus tard";
+
 /* Button to show the password change dialog
    Single button to show the password change dialog */
 "CHANGE_PASSWORD_WITH_DOTS" = "Modifier le mot de passe…";
@@ -62,6 +176,9 @@
 
 /* Button title in the key file selection dialog for selecting a key */
 "CHOOSE_FILE_BUTTON_TITLE" = "Sélectionner";
+
+/* Clear Autotype Button */
+"CLEAR_AUTOTYPE" = "Vider la saisie automatique";
 
 /* Menu to clear recent searches */
 "CLEAR_RECENT_SEARCHES" = "Effacer les recherches récentes";
@@ -144,7 +261,7 @@
 /* Context menu that copies reference to username */
 "COPY_USERNAME_REFERENCE" = "Copier la référence du nom d'utilisateur";
 
-/* Curstom attribute reference item */
+/* Custom attribute reference item */
 "CUSTOM_ATTRIBUTE" = "Attribut personnalisé";
 
 /* Title for menu for custom search filters */
@@ -199,13 +316,19 @@
 "DRAG_GROUP" = "Glisser-déposer le groupe";
 
 /* Action name for duplicating entries */
-"DUPLICATE_ENTRIES_%ld" = "Entrées dupliquées %ld";
+"DUPLICATE_ENTRIES_ACTION_NAME" = "Dupliquer les entrées";
 
 /* Menu item to directly diplicate an entry */
 "DUPLICATE_ENTRY" = "Dupliquer l'entrée";
 
 /* Menu item to duplicate an entry with options how to duplicate. Will present a dialog. */
 "DUPLICATE_ENTRY_WITH_OPTIONS" = "Dupliquer l'entrée…";
+
+/* Menu item to directly diplicate a group */
+"DUPLICATE_GROUP" = "Dupliquer le groupe";
+
+/* Action name for duplicating groups */
+"DUPLICATE_GROUPS_ACTION_NAME" = "Dupliquer le groupe";
 
 /* Menu item in the database outline context menu to change the template group
    Menu item on the add entry context menu to edit template groups */
@@ -238,11 +361,17 @@
 /* Error description given when adding an invalid plugin */
 "ERROR_INVALID_PLUGIN" = "Plugin invalide";
 
+/* Error description for missing accessibility permissions */
+"ERROR_NO_ACCESSIBILITY_PERMISSIONS" = "MacPass n'a pas la permission de contrôler votre ordinateur (Accessibilité)";
+
+/* Error description for missing screen recording permissions */
+"ERROR_NO_PERMISSION_TO_RECORD_SCREEN" = "MacPass n'a pas la permission d'enregistrer votre écran";
+
 /* Passwords do not match */
 "ERROR_PASSWORD_MISSMATCH" = "Mot de passe incorrect !";
 
 /* Passwords do not match, keyfile is invalid */
-"ERROR_PASSWORD_MISSMATCH_INVALID_KEYFILE" = "Mot de passe ou clé incorrect(e) !";
+"ERROR_PASSWORD_MISSMATCH_INVALID_KEYFILE" = "Mot de passe et clé incorrects !";
 
 /* Recommend/Enforce key change intervall format */
 "EVERY_%ld_DAYS" = "Tous les %ld jours";
@@ -252,6 +381,19 @@
 
 /* The master key was changed by an external program! */
 "EXTERN_CHANGE_OF_MASTERKEY" = "La clé principale a été changée par un programme externe";
+
+/* External file change strategy option: ask what to do */
+"FILE_CHANGE_STRATEGY_ASK" = "Demander";
+
+/* External file change strategy option: Keep local file an ignore external changes */
+"FILE_CHANGE_STRATEGY_KEEP_MINE" = "Garder ma version et ignorer les autres changements";
+
+/* Button in dialog to merge changes into file!
+   External file change strategy option: Merge external changes into local file. */
+"FILE_CHANGE_STRATEGY_MERGE" = "Fusionner les changements";
+
+/* External file change strategy option: Use the changed file and discard local changes */
+"FILE_CHANGE_STRATEGY_USE_OTHER" = "Charger la nouvelle version et ignorer la mienne";
 
 /* Informative text displayed when the file was change from another application */
 "FILE_CHANGED_BY_OTHERS_INFO_TEXT" = "Le fichier chargé n'est pas le même que celui sur le disque. Comment voulez-vous continuer ?";
@@ -321,6 +463,9 @@
 /* Action name when an entry was moved */
 "MOVE_ENTRY" = "Déplacer entrée";
 
+/* Menu displayed as popup selection for search options when multiple items are selected */
+"MULTIPLE_FILTERS_ACTIVE_WITH_DOTS" = "Plusieurs...";
+
 /* Name for a newly created Database */
 "NEW_DATABASE" = "Base de données";
 
@@ -356,6 +501,9 @@
    Notes reference item */
 "NOTES" = "Notes";
 
+/* Ok Button to dismiss disabled updates alert */
+"OK" = "OK";
+
 /* preset to expire after one montch from now */
 "ONE_MONTH" = "dans un mois";
 
@@ -375,19 +523,19 @@
 "OPEN_BUTTON_ADD_PLUGIN_OPEN_PANEL" = "Ajouter le plugin sélectionné";
 
 /* Open button in the open panel to import an XML file */
-"OPEN_BUTTON_IMPORT_XML_OPEN_PANEL" = "Ajouter le fichier sélectionné";
+"OPEN_BUTTON_IMPORT_XML_OPEN_PANEL" = "Importer le fichier sélectionné";
 
 /* Action button in Notification to open a document */
 "OPEN_DOCUMENT" = "Ouvrir";
-
-/* Action button in Notification to show the Accessibilty preferences */
-"OPEN_PREFERENCES" = "Ouvrir les préférences";
 
 /* Menu item to open the URL with the default application */
 "OPEN_URL" = "Ouvrir l'URL";
 
 /* Select Browser */
-"OTHER_BROWSER" = "Sélectionner le navigateur";
+"OTHER_BROWSER" = "Sélectionner le navigateur...";
+
+/* Value field for reference lookup */
+"OUTPUT_VALUE" = "Valeur de sortie";
 
 /* Menu item to toggle display of password column in entry table
    Password column title
@@ -418,8 +566,11 @@
 /* Menu item to perform autotype with the selected entry */
 "PERFORM_AUTOTYPE_FOR_ENTRY" = "Saisie automatique";
 
+/* Info about how many character has to pick in pickchar dialog */
+"PICKCHAR_INFO_MESSAGE_PICK_CHARACTERS_%ld" = "Veuillez choisir %ld caractères";
+
 /* Window displayed to the user to pick an amout of characters */
-"PICKCHAR_WINDOW_TITLE" = "Choix du nombre de caractères";
+"PICKCHAR_WINDOW_TITLE" = "Sélectionneur de caractères";
 
 /* Count of picked characters in pickchars dialog if no limit is set */
 "PICKED_%ld_CHARACTERS" = "%ld caractères sélectionnés";
@@ -475,6 +626,9 @@
 /* Label for plugin settings tab */
 "PLUGIN_SETTINGS" = "Plugins";
 
+/* Generic message displayed if no details are know why a plugin was not loaded. */
+"PLUGIN_SETTINGS_GENERIC_ERROR_MESSAGE" = "Le plugin n'a pas pu être chargé.";
+
 /* Plugin version. Include a %@ placeholder for version string */
 "PLUGIN_VERSION_%@" = "Version du plugin : %@";
 
@@ -488,12 +642,15 @@
 "RECOMMEND_PASSWORD_CHANGE_ALERT_DESCRIPTION" = "Il est recommandé de changer le mot de passe et/ou le fichier clé.";
 
 /* Message text for the recommend password change alert */
-"RECOMMEND_PASSWORD_CHANGE_ALERT_TITLE" = "Changez le mot de passe de la base de données !";
+"RECOMMEND_PASSWORD_CHANGE_ALERT_TITLE" = "Veuillez changer le mot de passe de la base de données !";
+
+/* Updated at text when the local plugin defintino is used */
+"REPOSITORY_UPDATED_AT_LOCAL" = "Jamais (utiliser la version locale)";
 
 /* Restart */
 "RESTART" = "Redémarrage";
 
-/* Action to restore and Entry to a previous state of it's history */
+/* Action to restore an Entry to its previous state of it's history */
 "RESTORE_HISTORY_ENTRY" = "Rétablir l'historique de l'entrée";
 
 /* Menu item to save the selected attached file.
@@ -512,6 +669,9 @@
 /* Search option: Find duplicate passwords */
 "SEARCH_DUPLICATE_PASSWORDS" = "Mots de passe dupliqués";
 
+/* Placeholder string displayed in the search field in the toolbar */
+"SEARCH_EVERYWHERE" = "Rechercher partout";
+
 /* Search option: Find expired entries */
 "SEARCH_EXPIRED_ENTRIES" = "Expirées";
 
@@ -521,14 +681,17 @@
 /* Disable search menu item */
 "SEARCH_NO" = "Exclure de la recherche";
 
+/* Search field for references lookup */
+"SEARCH_VALUE" = "Rechercher une valeur";
+
 /* Enable search menu item */
 "SEARCH_YES" = "Inclure dans la recherche";
 
 /* Menu item title for the expiry preset selection menu in the date picker */
-"SELECT_DATE_PRESET" = "Date relative…";
+"SELECT_DATE_PRESET" = "Utiliser un préréglage…";
 
 /* Message on the open panel for selecting which browser to use for opening URLs */
-"SELECT_DEFAULT_BROWSER_OPEN_PANEL_MESSAGE" = "Navigateur par défaut";
+"SELECT_DEFAULT_BROWSER_OPEN_PANEL_MESSAGE" = "Sélectionner le navigateur par défaut.";
 
 /* Label for the select browser button on the open panel for selecting which browser to use for opening URLs */
 "SELECT_DEFAULT_BROWSER_OPEN_PANEL_SELECT_BUTTON" = "Choix du navigateur";
@@ -538,6 +701,15 @@
 
 /* Menu displayed as popup selection for search options if no filter is selected */
 "SELECT_FILTER_WITH_DOTS" = "Sélectionner…";
+
+/* Checkbox in dialog to set the selection as default file change strategy! */
+"SET_AS_DEFAULT_FILE_CHANGE_STRATEGY" = "Utiliser cette méthode par défaut. Vous pouvez changer ce paramètre dans les préférences.";
+
+/* Action button in Notification to show the Autotype Doctor */
+"SHOW_AUTOTYPE_DOCTOR" = "Afficher le docteur de saisie automatique";
+
+/* Menu item to show the entries group in the outline view */
+"SHOW_GROUP_IN_OUTLINE" = "Afficher le groupe dans la vue générale";
 
 /* Menu item to show the history of the selected entry
    Toolbar item to toggle history display */
@@ -555,6 +727,42 @@
 /* Toolbar item to perform autotype */
 "TOOLBAR_PERFORM_AUTOTYPE_FOR_ENTRY" = "Saisie automatique";
 
+/* Touchbar button label for choosing the keyfile */
+"TOUCHBAR_CHOOSE_KEYFILE" = "Choisir le fichier clé";
+
+/* Touchbar button label for copying the password */
+"TOUCHBAR_COPY_PASSWORD" = "Copier le mot de passe";
+
+/* Touchbar button label for copying the username */
+"TOUCHBAR_COPY_USERNAME" = "Copier le nom d'utilisateur";
+
+/* Touchbar button label for deleting elements */
+"TOUCHBAR_DELETE" = "Supprimer";
+
+/* Touchbar button label for opening the popover to edit */
+"TOUCHBAR_EDIT" = "Modifier";
+
+/* Touchbar button label for locking the database */
+"TOUCHBAR_LOCK_DATABASE" = "Verrouiller la base de données";
+
+/* Touchbar button label for creating a new item */
+"TOUCHBAR_NEW_ENTRY" = "Nouvelle entrée";
+
+/* Touchbar button label for creating a new group */
+"TOUCHBAR_NEW_GROUP" = "Nouveau groupe";
+
+/* Touchbar button label for performing autotype */
+"TOUCHBAR_PERFORM_AUTOTYPE" = "Effectuer une saisie automatique";
+
+/* Touchbar button label for searching the database */
+"TOUCHBAR_SEARCH" = "Rechercher une base de données";
+
+/* Touchbar button label for showing the password */
+"TOUCHBAR_SHOW_PASSWORD" = "Afficher le mot de passe";
+
+/* Touchbar button label for unlocking the database */
+"TOUCHBAR_UNLOCK_DATABASE" = "Déverrouiller la base de données";
+
 /* Move Entry to Trash */
 "TRASH_ENTRY" = "Effacer entrée";
 
@@ -570,6 +778,12 @@
 /* Unknown database format. */
 "UNKNOWN_FORMAT" = "Format inconnu";
 
+/* Database format is unknown since the file is not saved yet */
+"UNKNOWN_FORMAT_FILE_NOT_SAVED_YET" = "Format inconnu, la base de données n'est pas encore sauvegardée.";
+
+/* No comment provided by engineer. */
+"UNKNOWN_TOOLBAR_ITEM" = "Élément de barre d'outils inconnu";
+
 /* Update Settings Label */
 "UPDATE_PREFERENCES" = "Mises à jour";
 
@@ -584,8 +798,24 @@
    Username reference item */
 "USERNAME" = "Utilisateur";
 
+/* Displayed name when uuid field was copied
+   UUID reference item */
+"UUID" = "UUID";
+
+/* Error message displayed when the current database file is also set as the key file */
+"WARNING_CURRENT_DATABASE_FILE_SELECTED_AS_KEY_FILE" = "Vous ne pouvez pas sélectionner le fichier de base de données courant comme fichier clé.";
+
+/* Error message displayed when a keepass database file is set as the key file */
+"WARNING_DATABASE_FILE_SELECTED_AS_KEY_FILE" = "Vous ne devez pas utiliser un fichier de base de données come clé car la base pourrait changer et vous empêcher de réouvrir le fichier actuel.";
+
 /* No Key or Password */
 "WARNING_NO_PASSWORD_OR_KEYFILE" = "Aucun mot de passe ou clé !";
+
+/* Informative Text displayed when clearing the Trash */
+"WARNING_ON_DELETE_TRASHED_NODE_DESCRIPTION" = "Le/les fichier(s) dans la corbeille vont être supprimés !";
+
+/* Message text for the alert displayed when deleting a node */
+"WARNING_ON_DELETE_TRASHED_NODE_TITLE" = "Suppression des éléments dans la corbeille";
 
 /* Informative Text displayed when clearing the Trash */
 "WARNING_ON_EMPTY_TRASH_DESCRIPTION" = "Vider la corbeille est définitif.";
@@ -598,6 +828,9 @@
 
 /* No comment provided by engineer. */
 "WARNING_ON_SAVE_NO_PASSWORD_OR_KEY_SET_SUGGESTION" = "Veuillez définir un mot de passe ou une clé pour cette base de données. Quitter cette opération va annuler tous les changements et verrouiller le document";
+
+/* Text displayed when no recent documents can be displayed in */
+"WELCOME_WINDOW_NO_RECENT_DOCUMENTS" = "Pas de documents récents";
 
 /* Label for the workflow settings tab */
 "WORKFLOW_SETTINGS" = "Workflow";

--- a/MacPass/fr.lproj/Localizable.stringsdict
+++ b/MacPass/fr.lproj/Localizable.stringsdict
@@ -31,11 +31,27 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
 			<key>one</key>
-			<string>Dupliquer l&apos;entrée</string>
+			<string>Dupliquer l'entrée</string>
 			<key>other</key>
 			<string>Dupliquer les entrées</string>
 			<key>zero</key>
 			<string>Dupliquer les entrées</string>
+		</dict>
+	</dict>
+	<key>DUPLICATE_GROUPS_ACTION_NAME</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@groupes@</string>
+		<key>groups</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>Groupe dupliqué</string>
+			<key>other</key>
+			<string>Groupes dupliqués</string>
 		</dict>
 	</dict>
 	<key>EVERY_%ld_DAYS</key>

--- a/MacPass/fr.lproj/MainMenu.strings
+++ b/MacPass/fr.lproj/MainMenu.strings
@@ -4,7 +4,7 @@
 /* Class = "NSMenuItem"; title = "Item"; ObjectID = "3st-rv-EeQ"; */
 "3st-rv-EeQ.title" = "Elément";
 
-/* Class = "NSMenu"; title = "Import"; ObjectID = "4q9-u1-pcm"; */
+/* Class = "NSMenu"; title = "Import From"; ObjectID = "4q9-u1-pcm"; */
 "4q9-u1-pcm.title" = "Importer";
 
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
@@ -29,7 +29,7 @@
 "57.title" = "MacPass";
 
 /* Class = "NSMenuItem"; title = "About MacPass"; ObjectID = "58"; */
-"58.title" = "A propos de MacPass";
+"58.title" = "À propos de MacPass";
 
 /* Class = "NSMenuItem"; title = "Open…"; ObjectID = "72"; */
 "72.title" = "Ouvrir…";
@@ -44,7 +44,7 @@
 "81.title" = "Fichier";
 
 /* Class = "NSMenuItem"; title = "New Database"; ObjectID = "82"; */
-"82.title" = "Nouveau";
+"82.title" = "Nouvelle base de données";
 
 /* Class = "NSMenuItem"; title = "File"; ObjectID = "83"; */
 "83.title" = "Fichier";
@@ -139,7 +139,7 @@
 /* Class = "NSMenuItem"; title = "Toggle Inspector"; ObjectID = "1181"; */
 "1181.title" = "Afficher l'inspecteur";
 
-/* Class = "NSMenuItem"; title = "Show Password Generator"; ObjectID = "1200"; */
+/* Class = "NSMenuItem"; title = "Password Generator"; ObjectID = "1200"; */
 "1200.title" = "Afficher le générateur de mot de passe";
 
 /* Class = "NSMenuItem"; title = "Change Master Password…"; ObjectID = "1203"; */
@@ -157,7 +157,7 @@
 /* Class = "NSMenuItem"; title = "Lock"; ObjectID = "1261"; */
 "1261.title" = "Verrouiller";
 
-/* Class = "NSMenuItem"; title = "Import"; ObjectID = "aTb-sW-nUd"; */
+/* Class = "NSMenuItem"; title = "Import From"; ObjectID = "aTb-sW-nUd"; */
 "aTb-sW-nUd.title" = "Importer";
 
 /* Class = "NSMenuItem"; title = "Quicklook"; ObjectID = "aVO-9F-Lwc"; */
@@ -172,7 +172,7 @@
 /* Class = "NSMenuItem"; title = "Fix Autotype…"; ObjectID = "nx7-Vf-LiD"; */
 "nx7-Vf-LiD.title" = "Réparer la saisie automatique…";
 
-/* Class = "NSMenu"; title = "Export"; ObjectID = "p8h-Fg-h1O"; */
+/* Class = "NSMenu"; title = "Export To"; ObjectID = "p8h-Fg-h1O"; */
 "p8h-Fg-h1O.title" = "Exporter";
 
 /* Class = "NSMenuItem"; title = "XML…"; ObjectID = "rW0-r1-QYL"; */
@@ -181,7 +181,7 @@
 /* Class = "NSMenu"; title = "Item"; ObjectID = "Ttt-tR-emo"; */
 "Ttt-tR-emo.title" = "Elément";
 
-/* Class = "NSMenuItem"; title = "Export"; ObjectID = "tz9-yK-pOf"; */
+/* Class = "NSMenuItem"; title = "Export To"; ObjectID = "tz9-yK-pOf"; */
 "tz9-yK-pOf.title" = "Exporter";
 
 /* Class = "NSMenuItem"; title = "Focus Inspector"; ObjectID = "Zje-Me-5c8"; */
@@ -192,4 +192,7 @@
 
 /* Class = "NSMenuItem"; title = "Merge With…"; ObjectID = "zvE-0h-UxI"; */
 "zvE-0h-UxI.title" = "Fusionner avec…";
+
+/* Class = "NSMenuItem"; title = "Autotype Doctor"; ObjectID = "zWx-Re-iuJ"; */
+"zWx-Re-iuJ.title" = "Docteur de saisie automatique";
 

--- a/MacPass/fr.lproj/PasswordCreatorView.strings
+++ b/MacPass/fr.lproj/PasswordCreatorView.strings
@@ -5,7 +5,7 @@
 "179.title" = "Longueur :";
 
 /* Class = "NSBox"; title = "Character options"; ObjectID = "332"; */
-"332.title" = "Cacactères autorisés";
+"332.title" = "Caractères autorisés";
 
 /* Class = "NSButtonCell"; title = "A-Z"; ObjectID = "453"; */
 "453.title" = "A-Z";
@@ -39,6 +39,9 @@
 
 /* Class = "NSButtonCell"; title = "Use default only for selected entry"; ObjectID = "cfZ-5F-Nge"; */
 "cfZ-5F-Nge.title" = "Utiliser par défaut uniquement pour l'entrée sélectionnée";
+
+/* Class = "NSButtonCell"; title = "Use characters from every group"; ObjectID = "CMc-Uh-Fo5"; */
+"CMc-Uh-Fo5.title" = "Utiliser des caractères de chaque groupe";
 
 /* Class = "NSButtonCell"; title = "Set Default"; ObjectID = "Wvs-Md-Ob8"; */
 "Wvs-Md-Ob8.title" = "Utiliser par défaut";

--- a/MacPass/fr.lproj/PasswordEditWindow.strings
+++ b/MacPass/fr.lproj/PasswordEditWindow.strings
@@ -1,7 +1,7 @@
 /* Class = "NSWindow"; title = "Change Password"; ObjectID = "1"; */
 "1.title" = "Modifier le mot de passe";
 
-/* Class = "NSTextFieldCell"; title = "Missmatching Passwords"; ObjectID = "14"; */
+/* Class = "NSTextFieldCell"; title = "Mismatching Passwords"; ObjectID = "14"; */
 "14.title" = "Les mots de passe ne correspondent pas";
 
 /* Class = "NSSecureTextFieldCell"; placeholderString = "Repeat Password"; ObjectID = "15"; */

--- a/MacPass/fr.lproj/PasswordInputView.strings
+++ b/MacPass/fr.lproj/PasswordInputView.strings
@@ -13,6 +13,9 @@
 /* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "erj-mR-UyO"; */
 "erj-mR-UyO.title" = "Annuler";
 
+/* Class = "NSTextFieldCell"; title = "key_file_warnig"; ObjectID = "f6J-5f-ZvP"; */
+"f6J-5f-ZvP.title" = "avertissement_fichier_clé";
+
 /* Class = "NSButtonCell"; title = "Password"; ObjectID = "IU9-5u-jn9"; */
 "IU9-5u-jn9.title" = "Mot de passe";
 

--- a/MacPass/fr.lproj/PickfieldView.strings
+++ b/MacPass/fr.lproj/PickfieldView.strings
@@ -13,6 +13,9 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "fil-tT-GXX"; */
 "fil-tT-GXX.title" = "Libellé de cellule";
 
+/* Class = "NSTextFieldCell"; title = "Header View Cell"; ObjectID = "kTy-VO-Xlg"; */
+"kTy-VO-Xlg.title" = "Cellule de vue d'en-tête";
+
 /* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "rVo-ud-5fs"; */
 "rVo-ud-5fs.headerCell.title" = "Valeur";
 

--- a/MacPass/fr.lproj/PluginPreferences.strings
+++ b/MacPass/fr.lproj/PluginPreferences.strings
@@ -7,6 +7,9 @@
 /* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "fug-79-n9g"; */
 "fug-79-n9g.title" = "Vue en tableau";
 
+/* Class = "NSTextFieldCell"; title = "If enabled, a remote connection is established to macpassapp.org"; ObjectID = "i3S-9b-Bpf"; */
+"i3S-9b-Bpf.title" = "Si activé, une connection vers macpassapp.org sera établie";
+
 /* Class = "NSTextFieldCell"; title = "Plugin Settings Info"; ObjectID = "OOr-SW-jZb"; */
 "OOr-SW-jZb.title" = "Paramètres du plugin";
 
@@ -14,7 +17,10 @@
 "sqO-8H-n1y.title" = "Parcourir les plugins disponibles…";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "STt-PQ-Szr"; */
-"STt-PQ-Szr.title" = "Libellé de la cellule";
+"STt-PQ-Szr.title" = "Libellé de cellule";
+
+/* Class = "NSButtonCell"; title = "Download current Plugin information"; ObjectID = "uHR-uL-Ddm"; */
+"uHR-uL-Ddm.title" = "Télécharger les informations du plugin actuel";
 
 /* Class = "NSBox"; title = "Box"; ObjectID = "vBs-Ga-aq0"; */
 "vBs-Ga-aq0.title" = "Case";

--- a/MacPass/fr.lproj/PluginRepositoryBrowserView.strings
+++ b/MacPass/fr.lproj/PluginRepositoryBrowserView.strings
@@ -1,3 +1,6 @@
+/* Class = "NSButtonCell"; title = "Action"; ObjectID = "6jQ-Uk-uqD"; */
+"6jQ-Uk-uqD.title" = "Action";
+
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "cFE-KE-Xjx"; */
 "cFE-KE-Xjx.title" = "Libellé de cellule";
 
@@ -8,7 +11,7 @@
 "DRt-Gz-DUm.title" = "Vue en tableau";
 
 /* Class = "NSTableColumn"; headerCell.title = "Status"; ObjectID = "g1Q-BS-vCR"; */
-"g1Q-BS-vCR.headerCell.title" = "Etat";
+"g1Q-BS-vCR.headerCell.title" = "État";
 
 /* Class = "NSTableColumn"; headerCell.title = "Latest Version"; ObjectID = "hFg-AD-SqD"; */
 "hFg-AD-SqD.headerCell.title" = "Dernière version";
@@ -21,6 +24,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Last updated:"; ObjectID = "ntD-sJ-NRw"; */
 "ntD-sJ-NRw.title" = "Dernière mise à jour :";
+
+/* Class = "NSTableColumn"; headerCell.title = "Plugin"; ObjectID = "Nzo-rR-Hfx"; */
+"Nzo-rR-Hfx.headerCell.title" = "Plugin";
 
 /* Class = "NSButtonCell"; title = "Refresh"; ObjectID = "NZw-nO-lZ3"; */
 "NZw-nO-lZ3.title" = "Rafraîchir";

--- a/MacPass/fr.lproj/ReferenceBuilderView.strings
+++ b/MacPass/fr.lproj/ReferenceBuilderView.strings
@@ -23,5 +23,5 @@
 "r1V-VE-ngy.title" = "Référence";
 
 /* Class = "NSMenuItem"; title = "Matching"; ObjectID = "yT1-XL-k6a"; */
-"yT1-XL-k6a.title" = "Correspondance";
+"yT1-XL-k6a.title" = "Correspondant";
 

--- a/MacPass/fr.lproj/SavePanelAccessoryView.strings
+++ b/MacPass/fr.lproj/SavePanelAccessoryView.strings
@@ -1,6 +1,15 @@
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "4"; */
 "4.title" = "Autres vues";
 
+/* Class = "NSMenuItem"; title = "KeePass 1 (KDB)"; ObjectID = "5"; */
+"5.title" = "KeePass 1 (KDB)";
+
+/* Class = "NSMenuItem"; title = "KeePass 2 (KDBX)"; ObjectID = "6"; */
+"6.title" = "KeePass 2 (KDB)";
+
+/* Class = "NSTextFieldCell"; title = "Format:"; ObjectID = "12"; */
+"12.title" = "Format :";
+
 /* Class = "NSTextFieldCell"; title = "Not all Information inside your current database can be stored with this format."; ObjectID = "52"; */
 "52.title" = "Certaines informations de votre base de données courante ne peuvent être enregistrées avec ce format.";
 

--- a/MacPass/fr.lproj/WorkflowPreferences.strings
+++ b/MacPass/fr.lproj/WorkflowPreferences.strings
@@ -1,4 +1,4 @@
-/* Class = "NSButtonCell"; title = "Hide application after copying to clipboard "; ObjectID = "1Vr-nY-Ogv"; */
+/* Class = "NSButtonCell"; title = "Hide application after copying to clipboard"; ObjectID = "1Vr-nY-Ogv"; */
 "1Vr-nY-Ogv.title" = "Masquer l'application après copie dans le presse-papiers";
 
 /* Class = "NSBox"; title = "Entry Table"; ObjectID = "2"; */


### PR DESCRIPTION
First of all, thank you for maintaining this very useful app 🙂.

I **added 121 missing french translations** and **tweaked some existing one**.
The app is now **fully translated in French**, there is **no missing french strings** anymore.

Before:
<img width="955" alt="Capture d’écran 2020-02-29 à 00 40 53" src="https://user-images.githubusercontent.com/2452603/75568109-a8f8fd00-5a8d-11ea-9357-8084f10927b9.png">

After:
<img width="1066" alt="Capture d’écran 2020-02-29 à 00 40 26" src="https://user-images.githubusercontent.com/2452603/75568162-bc0bcd00-5a8d-11ea-8ef9-705601e22e8a.png">

This will fix these 2 issues:
- https://github.com/MacPass/MacPass/issues/1015
- https://github.com/MacPass/MacPass/issues/1000