### PR TITLE
focus password input

### DIFF
--- a/MacPass/MPDocumentWindowController.m
+++ b/MacPass/MPDocumentWindowController.m
@@ -311,6 +311,7 @@ typedef void (^MPPasswordChangedBlock)(BOOL didChangePassword);
     self.passwordInputController = [[MPPasswordInputController alloc] init];
   }
   self.contentViewController = self.passwordInputController;
+  [self.window makeFirstResponder:self.passwordInputController.reconmendedFirstResponder];
   [self.passwordInputController requestPasswordWithMessage:message cancelLabel:nil completionHandler:^BOOL(NSString *password, NSURL *keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
     if(didCancel) {
       return NO;


### PR DESCRIPTION
In `0.7.9` password input field was in focus on app start. It stopped working with this change:

https://github.com/MacPass/MacPass/commit/e3352efe49abb5e6a126fd40c222095bc1243c7d#diff-1846955fb3ac54fead17acb542fbb888L200

This patch reverts previous behavior, for the password input only.