### PR TITLE
TouchID unlock Feature for MacPass.

### DIFF
--- a/MacPass.xcodeproj/project.pbxproj
+++ b/MacPass.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		6021FE9818E1650F00C3BC51 /* DatabaseSettingsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6021FE9A18E1650F00C3BC51 /* DatabaseSettingsWindow.xib */; };
 		7837112C225540D1009BD28D /* PluginRepositoryBrowserView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7837112E225540D1009BD28D /* PluginRepositoryBrowserView.xib */; };
 		78E1F8B022E3A5D600E738AE /* AutotypeDoctorReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 78E1F8B222E3A5D600E738AE /* AutotypeDoctorReportViewController.xib */; };
+		AF105CF325FE5B2000C4FD3C /* MPTouchIdCompositeKeyStore.m in Sources */ = {isa = PBXBuildFile; fileRef = AF105CF125FE5B2000C4FD3C /* MPTouchIdCompositeKeyStore.m */; };
 		FA13910C1F9CD9EB0033D256 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = FA13910A1F9CD9EB0033D256 /* Localizable.stringsdict */; };
 		FA9FD3271FB5E8F4003CEDD6 /* AutotypeCandidateSelectionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA9FD3291FB5E8F4003CEDD6 /* AutotypeCandidateSelectionView.xib */; };
 		FA9FD32C1FB5EDD3003CEDD6 /* AutotypeBuilderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA9FD32E1FB5EDD3003CEDD6 /* AutotypeBuilderView.xib */; };
@@ -1043,6 +1044,8 @@
 		ABE8662E2316617500201125 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		ABE8662F2316617500201125 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/AutotypeDoctorReportViewController.strings"; sourceTree = "<group>"; };
 		ABE86630231662D200201125 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/PluginDataView.strings"; sourceTree = "<group>"; };
+		AF105CF125FE5B2000C4FD3C /* MPTouchIdCompositeKeyStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPTouchIdCompositeKeyStore.m; sourceTree = "<group>"; };
+		AF105CF225FE5B2000C4FD3C /* MPTouchIdCompositeKeyStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPTouchIdCompositeKeyStore.h; sourceTree = "<group>"; };
 		BB3E050C1FE9D1CA00F0B46F /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/AutotypeCandidateSelectionView.strings; sourceTree = "<group>"; };
 		BB3E050D1FE9D1CB00F0B46F /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		BB3E050E1FE9D1CC00F0B46F /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/ReferenceBuilderView.strings; sourceTree = "<group>"; };
@@ -1298,6 +1301,8 @@
 				4C4B7EF717A4B335000234C7 /* MPUniqueCharactersFormatter.m */,
 				4C3C4EAD18D7039300153127 /* MPValueTransformerHelper.h */,
 				4C3C4EAE18D7039300153127 /* MPValueTransformerHelper.m */,
+				AF105CF225FE5B2000C4FD3C /* MPTouchIdCompositeKeyStore.h */,
+				AF105CF125FE5B2000C4FD3C /* MPTouchIdCompositeKeyStore.m */,
 			);
 			name = Helper;
 			sourceTree = "<group>";
@@ -2215,6 +2220,7 @@
 				4C978E0D19AE54AB003067DF /* MPFlagsHelper.m in Sources */,
 				4C6F228919A4A7F90012310C /* MPAutotypeClear.m in Sources */,
 				4C0B038C18E36DA400B9F9C9 /* MPFixAutotypeWindowController.m in Sources */,
+				AF105CF325FE5B2000C4FD3C /* MPTouchIdCompositeKeyStore.m in Sources */,
 				4C7679BF1D76D6D8001F33D6 /* MPErrorRecoveryAttempter.m in Sources */,
 				4CAD338F205169D30068587E /* MPPluginRepositoryItem.m in Sources */,
 				4C9BFFFB1FD19B5400264B16 /* MPPrettyPasswordTransformer.m in Sources */,

--- a/MacPass.xcodeproj/project.pbxproj
+++ b/MacPass.xcodeproj/project.pbxproj
@@ -1904,6 +1904,7 @@
 				4C77E35F15B84A240093A587 /* Frameworks */,
 				4C77E36015B84A240093A587 /* Resources */,
 				4C44DB1B1C08999F00774EB3 /* Versioning */,
+				AF786C6F24D327A400240320 /* ShellScript */,
 				4CC5D36618A1332000AF7FA8 /* CopyFiles */,
 			);
 			buildRules = (
@@ -2119,6 +2120,23 @@
 			shellPath = /bin/sh;
 			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git rev-parse --abbrev-ref HEAD`\ngit_count=`$git rev-list $branch_name |wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_number=\"${git_count}0\"\nif [ $CONFIGURATION != \"Release\" ]; then\n  if [ $branch_name != \"master\" ] && [ $branch_name != release* ]; then\n    build_number+=\"-$branch_name\"\n  fi\nfi\nif [ \"$CI\" = \"true\" ]; then\nbuild_date=`date +\"%Y%m%d%H%m%S\"`\nbuild_number=\"$build_date-continuous\"\nfi\n\nplist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\ndsym_plist=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$plist\"\nif [ -f \"$DSYM_INFO_PLIST\" ] ; then\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$dsym_plist\"\nfi\n";
 			showEnvVarsInLog = 0;
+		};
+		AF786C6F24D327A400240320 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif [ \"$CODE_SIGNING_REQUIRED\" = \"NO\" ]\nthen\n    exit 0\nfi\n/usr/bin/codesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" --timestamp=none --preserve-metadata=identifier,entitlements,flags ./Carthage/Build/Mac/KeePassKit.framework/Versions/A/Frameworks/KissXML.framework\nexit $?\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -3064,6 +3082,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_ENTITLEMENTS = MacPass/MacPass.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "${CURRENT_PROJECT_VERSION}";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3094,6 +3113,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_ENTITLEMENTS = MacPass/MacPass.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "${CURRENT_PROJECT_VERSION}";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/MacPass.xcodeproj/project.pbxproj
+++ b/MacPass.xcodeproj/project.pbxproj
@@ -1904,7 +1904,6 @@
 				4C77E35F15B84A240093A587 /* Frameworks */,
 				4C77E36015B84A240093A587 /* Resources */,
 				4C44DB1B1C08999F00774EB3 /* Versioning */,
-				AF786C6F24D327A400240320 /* ShellScript */,
 				4CC5D36618A1332000AF7FA8 /* CopyFiles */,
 			);
 			buildRules = (
@@ -2120,23 +2119,6 @@
 			shellPath = /bin/sh;
 			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git rev-parse --abbrev-ref HEAD`\ngit_count=`$git rev-list $branch_name |wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_number=\"${git_count}0\"\nif [ $CONFIGURATION != \"Release\" ]; then\n  if [ $branch_name != \"master\" ] && [ $branch_name != release* ]; then\n    build_number+=\"-$branch_name\"\n  fi\nfi\nif [ \"$CI\" = \"true\" ]; then\nbuild_date=`date +\"%Y%m%d%H%m%S\"`\nbuild_number=\"$build_date-continuous\"\nfi\n\nplist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\ndsym_plist=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$plist\"\nif [ -f \"$DSYM_INFO_PLIST\" ] ; then\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$dsym_plist\"\nfi\n";
 			showEnvVarsInLog = 0;
-		};
-		AF786C6F24D327A400240320 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif [ \"$CODE_SIGNING_REQUIRED\" = \"NO\" ]\nthen\n    exit 0\nfi\n/usr/bin/codesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" --timestamp=none --preserve-metadata=identifier,entitlements,flags ./Carthage/Build/Mac/KeePassKit.framework/Versions/A/Frameworks/KissXML.framework\nexit $?\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -3081,8 +3063,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = MacPassAppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_ENTITLEMENTS = MacPass/MacPass.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "${CURRENT_PROJECT_VERSION}";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3112,8 +3094,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = MacPassAppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_ENTITLEMENTS = MacPass/MacPass.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "${CURRENT_PROJECT_VERSION}";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/MacPass/Base.lproj/IntegrationPreferences.xib
+++ b/MacPass/Base.lproj/IntegrationPreferences.xib
@@ -27,19 +27,19 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="411" height="520"/>
+            <rect key="frame" x="0.0" y="0.0" width="417" height="664"/>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="500" borderType="line" title="Autotype" translatesAutoresizingMaskIntoConstraints="NO" id="P9N-HM-wER">
-                    <rect key="frame" x="17" y="115" width="377" height="385"/>
+                    <rect key="frame" x="17" y="246" width="383" height="398"/>
                     <view key="contentView" id="faU-Ok-HJ3">
-                        <rect key="frame" x="3" y="3" width="371" height="367"/>
+                        <rect key="frame" x="3" y="3" width="377" height="380"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="j52-9L-k7c">
-                                <rect key="frame" x="16" y="17" width="339" height="340"/>
+                                <rect key="frame" x="16" y="17" width="345" height="353"/>
                                 <subviews>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="hMJ-Mo-xOM">
-                                        <rect key="frame" x="-2" y="298" width="343" height="42"/>
+                                        <rect key="frame" x="-2" y="311" width="349" height="42"/>
                                         <textFieldCell key="cell" controlSize="small" id="H37-ku-aTc">
                                             <font key="font" metaFont="smallSystem"/>
                                             <string key="title">Autotype might not work properly. Some issues where found that prevent Autotype or Global Autotype to work. Please run the Autotype Doctor to fix those issues.</string>
@@ -48,7 +48,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jai-b6-Qv4">
-                                        <rect key="frame" x="-6" y="262" width="177" height="32"/>
+                                        <rect key="frame" x="-7" y="276" width="171" height="32"/>
                                         <buttonCell key="cell" type="push" title="Run Autotype Doctor…" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="NP0-R3-m6n">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -58,14 +58,14 @@
                                         </connections>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="tik-Ar-FJg">
-                                        <rect key="frame" x="-2" y="245" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="258" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Enable global Autotype" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1qb-Rd-jYu">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="d6A-Vb-CMt">
-                                        <rect key="frame" x="0.0" y="218" width="281" height="21"/>
+                                        <rect key="frame" x="0.0" y="230" width="281" height="21"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buI-Wb-o3V">
                                                 <rect key="frame" x="-2" y="3" width="57" height="16"/>
@@ -107,14 +107,14 @@
                                         </customSpacing>
                                     </stackView>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uZQ-Gd-hfu">
-                                        <rect key="frame" x="-2" y="194" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="205" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Always show confirmation before executing Autotype" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rrU-70-Ara">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cUt-aB-oib">
-                                        <rect key="frame" x="-2" y="146" width="343" height="42"/>
+                                        <rect key="frame" x="-2" y="156" width="349" height="42"/>
                                         <textFieldCell key="cell" controlSize="small" selectable="YES" id="VjU-Hz-cu4">
                                             <font key="font" metaFont="smallSystem"/>
                                             <string key="title">If enabled, a dialog will show up before Autotype is executed even if only a single match was found to prevent accidental input and wrong matches</string>
@@ -123,42 +123,42 @@
                                         </textFieldCell>
                                     </textField>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="DAX-V8-Say">
-                                        <rect key="frame" x="-2" y="122" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="131" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry Title for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tmL-dT-D0G">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="8Wz-lo-AXG">
-                                        <rect key="frame" x="-2" y="100" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="107" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry URL for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="TzR-00-Vp3">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="TiO-ah-BlR">
-                                        <rect key="frame" x="-2" y="78" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="83" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry URL Host for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="B1D-j9-L8x">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="9MH-jx-GpG">
-                                        <rect key="frame" x="-2" y="56" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="59" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry Tags for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rbu-G7-MT8">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VK8-z4-2ci">
-                                        <rect key="frame" x="-2" y="34" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="35" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Interpret ⌃ as ⌘" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QfO-yG-l3F">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="wbP-A9-jpw">
-                                        <rect key="frame" x="-2" y="0.0" width="343" height="28"/>
+                                        <rect key="frame" x="-2" y="0.0" width="349" height="28"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="If enabled, every {CONTROL} command will be sent as ⌘. Only disable this if you are sure you need to." id="QRy-CY-ENC">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -205,20 +205,20 @@
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="500" borderType="line" title="Preview" translatesAutoresizingMaskIntoConstraints="NO" id="VVs-b5-cX9">
-                    <rect key="frame" x="17" y="16" width="377" height="95"/>
+                    <rect key="frame" x="17" y="145" width="383" height="97"/>
                     <view key="contentView" id="ww4-uR-8gP">
-                        <rect key="frame" x="3" y="3" width="371" height="77"/>
+                        <rect key="frame" x="3" y="3" width="377" height="79"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="LNw-5t-TS4">
-                                <rect key="frame" x="14" y="51" width="178" height="18"/>
+                                <rect key="frame" x="14" y="52" width="182" height="18"/>
                                 <buttonCell key="cell" type="check" title="Enable Quicklook Preview" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ERs-ct-Eyx">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="V6l-R9-hIj">
-                                <rect key="frame" x="14" y="17" width="343" height="28"/>
+                                <rect key="frame" x="14" y="17" width="349" height="28"/>
                                 <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="If enabled attached files will be copied to a temporary location for preview and deleted after the preview is closed." id="WmI-IB-Aso">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -239,17 +239,57 @@
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="V6l-R9-hIj" secondAttribute="trailing" constant="16" id="ivY-UD-QFJ"/>
                     </constraints>
                 </box>
+                <box title="Keychain" translatesAutoresizingMaskIntoConstraints="NO" id="ChZ-ku-FOP">
+                    <rect key="frame" x="17" y="16" width="383" height="125"/>
+                    <view key="contentView" id="ocY-lR-P2Z">
+                        <rect key="frame" x="3" y="3" width="377" height="107"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="u5z-ST-gTK">
+                                <rect key="frame" x="9" y="60" width="154" height="32"/>
+                                <buttonCell key="cell" type="push" title="Renew TouchID Key" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="b4n-g4-CtW">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="RenewTouchIdKey:" target="-2" id="dl7-WD-Abu"/>
+                                </connections>
+                            </button>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="9kv-ns-mQx">
+                                <rect key="frame" x="14" y="16" width="349" height="42"/>
+                                <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="LyC-Hd-ecK">
+                                    <font key="font" metaFont="smallSystem"/>
+                                    <string key="title">MacPass will no longer be able to unlock any Database with TouchID until it is successfully unlocked with the password and or keyfile.</string>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="9kv-ns-mQx" secondAttribute="bottom" constant="16" id="INC-l7-zwP"/>
+                            <constraint firstItem="u5z-ST-gTK" firstAttribute="leading" secondItem="ocY-lR-P2Z" secondAttribute="leading" constant="16" id="KDt-yM-fh3"/>
+                            <constraint firstItem="9kv-ns-mQx" firstAttribute="top" secondItem="u5z-ST-gTK" secondAttribute="bottom" constant="9" id="RjN-pw-qLc"/>
+                            <constraint firstItem="9kv-ns-mQx" firstAttribute="leading" secondItem="u5z-ST-gTK" secondAttribute="leading" id="X5L-Rj-Wky"/>
+                            <constraint firstItem="u5z-ST-gTK" firstAttribute="top" secondItem="ocY-lR-P2Z" secondAttribute="top" constant="20" symbolic="YES" id="guH-ws-dzX"/>
+                            <constraint firstAttribute="trailing" secondItem="9kv-ns-mQx" secondAttribute="trailing" constant="16" id="icu-An-dNK"/>
+                            <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="u5z-ST-gTK" secondAttribute="trailing" priority="240" constant="16" id="rni-sA-a7w"/>
+                        </constraints>
+                    </view>
+                </box>
             </subviews>
             <constraints>
+                <constraint firstItem="ChZ-ku-FOP" firstAttribute="trailing" secondItem="ww4-uR-8gP" secondAttribute="trailing" id="39G-i3-XQa"/>
+                <constraint firstItem="ChZ-ku-FOP" firstAttribute="top" secondItem="VVs-b5-cX9" secondAttribute="bottom" constant="8" symbolic="YES" id="3ub-U2-KCr"/>
                 <constraint firstItem="P9N-HM-wER" firstAttribute="top" secondItem="1" secondAttribute="top" constant="20" symbolic="YES" id="8fy-q5-VJy"/>
-                <constraint firstAttribute="bottom" secondItem="VVs-b5-cX9" secondAttribute="bottom" constant="20" symbolic="YES" id="TZB-qe-7eg"/>
+                <constraint firstItem="ChZ-ku-FOP" firstAttribute="leading" secondItem="ww4-uR-8gP" secondAttribute="leading" id="BQW-Zd-udd"/>
+                <constraint firstAttribute="bottom" secondItem="ChZ-ku-FOP" secondAttribute="bottom" constant="20" symbolic="YES" id="DBk-vZ-yOT"/>
                 <constraint firstItem="VVs-b5-cX9" firstAttribute="top" secondItem="P9N-HM-wER" secondAttribute="bottom" constant="8" symbolic="YES" id="VCX-JW-cBe"/>
                 <constraint firstItem="VVs-b5-cX9" firstAttribute="trailing" secondItem="P9N-HM-wER" secondAttribute="trailing" id="k9i-4T-WY0"/>
                 <constraint firstAttribute="trailing" secondItem="P9N-HM-wER" secondAttribute="trailing" constant="20" id="n5w-Cw-Bbt"/>
                 <constraint firstItem="P9N-HM-wER" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" id="ulV-xL-ldJ"/>
                 <constraint firstItem="VVs-b5-cX9" firstAttribute="leading" secondItem="P9N-HM-wER" secondAttribute="leading" id="z4a-9C-78h"/>
             </constraints>
-            <point key="canvasLocation" x="-1204" y="-1287"/>
+            <point key="canvasLocation" x="-1204.5" y="-1287.5"/>
         </customView>
     </objects>
 </document>

--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -152,14 +152,14 @@ DQ
                 <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="txI-yI-5nE">
                     <rect key="frame" x="157" y="204" width="195" height="14"/>
                     <textFieldCell key="cell" selectable="YES" title="key_file_warnig" id="f6J-5f-ZvP">
-                        <font key="font" metaFont="menu" size="11"/>
+                        <font key="font" metaFont="toolTip"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hs8-Tc-ezo">
                     <rect key="frame" x="72" y="287" width="72" height="18"/>
-                    <buttonCell key="cell" type="check" title="TouchID" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="h3C-Z4-x7N">
+                    <buttonCell key="cell" type="check" title="TouchID" bezelStyle="regularSquare" imagePosition="left" allowsMixedState="YES" inset="2" id="h3C-Z4-x7N">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>

--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -42,7 +42,7 @@
                     </pathCell>
                 </pathControl>
                 <imageView translatesAutoresizingMaskIntoConstraints="NO" id="262">
-                    <rect key="frame" x="230" y="312" width="48" height="48"/>
+                    <rect key="frame" x="230" y="332" width="48" height="48"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="48" id="273"/>
                         <constraint firstAttribute="width" constant="48" id="456"/>
@@ -50,7 +50,7 @@
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="02_MessageBoxWarningTemplate" id="263"/>
                 </imageView>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="268">
-                    <rect key="frame" x="199" y="288" width="110" height="16"/>
+                    <rect key="frame" x="199" y="308" width="110" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Wrong password!" id="269">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -75,14 +75,14 @@
                     </connections>
                 </secureTextField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="408">
-                    <rect key="frame" x="358" y="250" width="29" height="23"/>
+                    <rect key="frame" x="357" y="251" width="33" height="23"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSQuickLookTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="409">
                         <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="486">
-                    <rect key="frame" x="358" y="221" width="29" height="23"/>
+                    <rect key="frame" x="357" y="221" width="33" height="23"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSStopProgressTemplate" imagePosition="only" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="487">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -92,17 +92,17 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="d8O-Ha-rrS">
-                    <rect key="frame" x="72" y="254" width="81" height="18"/>
+                    <rect key="frame" x="66" y="254" width="85" height="18"/>
                     <buttonCell key="cell" type="check" title="Password" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="IU9-5u-jn9">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
                 <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tck-n8-s0U" userLabel="SubmitButtonContainer">
-                    <rect key="frame" x="140" y="175" width="247" height="21"/>
+                    <rect key="frame" x="166" y="176" width="223" height="20"/>
                     <subviews>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2pb-ZG-spA">
-                            <rect key="frame" x="-6" y="-7" width="82" height="32"/>
+                            <rect key="frame" x="-7" y="-7" width="76" height="32"/>
                             <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="erj-mR-UyO">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -115,7 +115,7 @@ Gw
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mQA-C0-JyU">
-                            <rect key="frame" x="76" y="-7" width="94" height="32"/>
+                            <rect key="frame" x="67" y="-7" width="88" height="32"/>
                             <buttonCell key="cell" type="push" title="Touch ID" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="W9h-1u-9kq">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -125,7 +125,7 @@ Gw
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2">
-                            <rect key="frame" x="170" y="-7" width="83" height="32"/>
+                            <rect key="frame" x="153" y="-7" width="77" height="32"/>
                             <buttonCell key="cell" type="push" title="Unlock" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -158,7 +158,7 @@ DQ
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hs8-Tc-ezo">
-                    <rect key="frame" x="72" y="287" width="72" height="18"/>
+                    <rect key="frame" x="66" y="287" width="76" height="18"/>
                     <buttonCell key="cell" type="check" title="TouchID" bezelStyle="regularSquare" imagePosition="left" allowsMixedState="YES" inset="2" id="h3C-Z4-x7N">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -172,7 +172,6 @@ DQ
                 <constraint firstItem="262" firstAttribute="top" relation="greaterThanOrEqual" secondItem="1" secondAttribute="top" constant="20" symbolic="YES" id="276"/>
                 <constraint firstAttribute="centerX" secondItem="262" secondAttribute="centerX" id="286"/>
                 <constraint firstAttribute="centerY" secondItem="338" secondAttribute="centerY" id="386"/>
-                <constraint firstItem="338" firstAttribute="top" secondItem="268" secondAttribute="bottom" constant="15" id="400"/>
                 <constraint firstItem="268" firstAttribute="top" secondItem="262" secondAttribute="bottom" constant="8" symbolic="YES" id="402"/>
                 <constraint firstItem="408" firstAttribute="top" secondItem="338" secondAttribute="top" id="411"/>
                 <constraint firstItem="268" firstAttribute="centerX" secondItem="338" secondAttribute="centerX" id="447"/>
@@ -192,9 +191,10 @@ DQ
                 <constraint firstItem="17" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="EOa-K4-v7J"/>
                 <constraint firstItem="338" firstAttribute="leading" secondItem="d8O-Ha-rrS" secondAttribute="trailing" constant="8" symbolic="YES" id="KYs-Ia-SVl"/>
                 <constraint firstItem="Hs8-Tc-ezo" firstAttribute="leading" secondItem="d8O-Ha-rrS" secondAttribute="leading" id="MO7-cs-9KQ"/>
+                <constraint firstItem="d8O-Ha-rrS" firstAttribute="top" secondItem="Hs8-Tc-ezo" secondAttribute="bottom" constant="17" id="Rhp-Gn-AaI"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="tck-n8-s0U" secondAttribute="bottom" constant="20" symbolic="YES" id="Sny-FR-cY1"/>
                 <constraint firstItem="tck-n8-s0U" firstAttribute="trailing" secondItem="486" secondAttribute="trailing" id="UtJ-18-p5u"/>
-                <constraint firstItem="Hs8-Tc-ezo" firstAttribute="firstBaseline" secondItem="268" secondAttribute="firstBaseline" id="e94-Kz-Ohn"/>
+                <constraint firstItem="Hs8-Tc-ezo" firstAttribute="firstBaseline" secondItem="268" secondAttribute="firstBaseline" constant="20" id="e94-Kz-Ohn"/>
                 <constraint firstItem="d8O-Ha-rrS" firstAttribute="centerY" secondItem="338" secondAttribute="centerY" id="kgB-jV-OGy"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="top" secondItem="241" secondAttribute="bottom" constant="8" symbolic="YES" id="lfg-eB-T2O"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="leading" secondItem="241" secondAttribute="leading" id="nGY-6Q-Vwy"/>
@@ -205,7 +205,7 @@ DQ
     </objects>
     <resources>
         <image name="02_MessageBoxWarningTemplate" width="16" height="16"/>
-        <image name="NSQuickLookTemplate" width="19" height="12"/>
-        <image name="NSStopProgressTemplate" width="11" height="11"/>
+        <image name="NSQuickLookTemplate" width="21" height="13"/>
+        <image name="NSStopProgressTemplate" width="14" height="13"/>
     </resources>
 </document>

--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +16,7 @@
                 <outlet property="passwordTextField" destination="338" id="495"/>
                 <outlet property="togglePasswordButton" destination="408" id="493"/>
                 <outlet property="touchIdButton" destination="mQA-C0-JyU" id="fM3-PG-1OB"/>
-                <outlet property="touchIdEnabled" destination="Hs8-Tc-ezo" id="9Go-LQ-mSw"/>
+                <outlet property="touchIdEnabledButton" destination="Hs8-Tc-ezo" id="9Go-LQ-mSw"/>
                 <outlet property="unlockButton" destination="2" id="ZRr-Ui-ExP"/>
                 <outlet property="view" destination="1" id="143"/>
             </connections>

--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -16,6 +16,7 @@
                 <outlet property="messageInfoTextField" destination="268" id="ahE-sq-QzR"/>
                 <outlet property="passwordTextField" destination="338" id="495"/>
                 <outlet property="togglePasswordButton" destination="408" id="493"/>
+                <outlet property="touchIdButton" destination="mQA-C0-JyU" id="fM3-PG-1OB"/>
                 <outlet property="unlockButton" destination="2" id="ZRr-Ui-ExP"/>
                 <outlet property="view" destination="1" id="143"/>
             </connections>
@@ -25,19 +26,6 @@
         <customView horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="1">
             <rect key="frame" x="0.0" y="0.0" width="508" height="526"/>
             <subviews>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2">
-                    <rect key="frame" x="310" y="168" width="83" height="32"/>
-                    <buttonCell key="cell" type="push" title="Unlock" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                        <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                    </buttonCell>
-                    <connections>
-                        <action selector="_submit:" target="-2" id="KZN-ap-nDc"/>
-                    </connections>
-                </button>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="17">
                     <rect key="frame" x="108" y="226" width="45" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Keyfile" id="18">
@@ -109,30 +97,67 @@ DQ
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2pb-ZG-spA">
-                    <rect key="frame" x="228" y="168" width="82" height="32"/>
-                    <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="erj-mR-UyO">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                        <string key="keyEquivalent" base64-UTF8="YES">
+                <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tck-n8-s0U" userLabel="SubmitButtonContainer">
+                    <rect key="frame" x="140" y="175" width="247" height="21"/>
+                    <subviews>
+                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2pb-ZG-spA">
+                            <rect key="frame" x="-6" y="-7" width="82" height="32"/>
+                            <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="erj-mR-UyO">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                                <string key="keyEquivalent" base64-UTF8="YES">
 Gw
 </string>
-                    </buttonCell>
-                    <connections>
-                        <action selector="_submit:" target="-2" id="aVF-1d-1Hq"/>
-                    </connections>
-                </button>
+                            </buttonCell>
+                            <connections>
+                                <action selector="_submit:" target="-2" id="aVF-1d-1Hq"/>
+                            </connections>
+                        </button>
+                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mQA-C0-JyU">
+                            <rect key="frame" x="76" y="-7" width="94" height="32"/>
+                            <buttonCell key="cell" type="push" title="Touch ID" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="W9h-1u-9kq">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="unlockWithTouchID:" target="-2" id="1yL-6V-t8q"/>
+                            </connections>
+                        </button>
+                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2">
+                            <rect key="frame" x="170" y="-7" width="83" height="32"/>
+                            <buttonCell key="cell" type="push" title="Unlock" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                                <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                            </buttonCell>
+                            <connections>
+                                <action selector="_submit:" target="-2" id="KZN-ap-nDc"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
                 <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="txI-yI-5nE">
                     <rect key="frame" x="157" y="204" width="195" height="14"/>
                     <textFieldCell key="cell" selectable="YES" title="key_file_warnig" id="f6J-5f-ZvP">
-                        <font key="font" metaFont="smallSystem"/>
+                        <font key="font" metaFont="menu" size="11"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="2" secondAttribute="bottom" constant="20" symbolic="YES" id="122"/>
                 <constraint firstItem="262" firstAttribute="top" relation="greaterThanOrEqual" secondItem="1" secondAttribute="top" constant="20" symbolic="YES" id="276"/>
                 <constraint firstAttribute="centerX" secondItem="262" secondAttribute="centerX" id="286"/>
                 <constraint firstAttribute="centerY" secondItem="338" secondAttribute="centerY" id="386"/>
@@ -150,19 +175,17 @@ Gw
                 <constraint firstItem="486" firstAttribute="leading" secondItem="241" secondAttribute="trailing" constant="8" symbolic="YES" id="489"/>
                 <constraint firstItem="486" firstAttribute="leading" secondItem="408" secondAttribute="leading" id="490"/>
                 <constraint firstItem="408" firstAttribute="trailing" secondItem="486" secondAttribute="trailing" id="492"/>
-                <constraint firstItem="2" firstAttribute="trailing" secondItem="486" secondAttribute="trailing" id="496"/>
+                <constraint firstItem="tck-n8-s0U" firstAttribute="top" secondItem="txI-yI-5nE" secondAttribute="bottom" constant="8" id="6tz-an-3SW"/>
                 <constraint firstItem="408" firstAttribute="leading" secondItem="338" secondAttribute="trailing" constant="8" symbolic="YES" id="7qE-8F-QgB"/>
-                <constraint firstItem="2pb-ZG-spA" firstAttribute="baseline" secondItem="2" secondAttribute="baseline" id="9nK-MH-Ozs"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="trailing" secondItem="241" secondAttribute="trailing" id="AVL-HO-SMq"/>
                 <constraint firstItem="17" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="EOa-K4-v7J"/>
                 <constraint firstItem="338" firstAttribute="leading" secondItem="d8O-Ha-rrS" secondAttribute="trailing" constant="8" symbolic="YES" id="KYs-Ia-SVl"/>
-                <constraint firstItem="2pb-ZG-spA" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="SUS-76-os4"/>
-                <constraint firstItem="2" firstAttribute="top" secondItem="txI-yI-5nE" secondAttribute="bottom" constant="8" symbolic="YES" id="jJs-hc-O2O"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="tck-n8-s0U" secondAttribute="bottom" constant="20" symbolic="YES" id="Sny-FR-cY1"/>
+                <constraint firstItem="tck-n8-s0U" firstAttribute="trailing" secondItem="486" secondAttribute="trailing" id="UtJ-18-p5u"/>
                 <constraint firstItem="d8O-Ha-rrS" firstAttribute="centerY" secondItem="338" secondAttribute="centerY" id="kgB-jV-OGy"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="top" secondItem="241" secondAttribute="bottom" constant="8" symbolic="YES" id="lfg-eB-T2O"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="leading" secondItem="241" secondAttribute="leading" id="nGY-6Q-Vwy"/>
                 <constraint firstItem="d8O-Ha-rrS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="vxq-YP-UhR"/>
-                <constraint firstItem="2" firstAttribute="leading" secondItem="2pb-ZG-spA" secondAttribute="trailing" constant="12" id="ytJ-5Z-5rT"/>
             </constraints>
             <point key="canvasLocation" x="-127" y="-46"/>
         </customView>

--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -16,7 +16,9 @@
                 <outlet property="messageInfoTextField" destination="268" id="ahE-sq-QzR"/>
                 <outlet property="passwordTextField" destination="338" id="495"/>
                 <outlet property="togglePasswordButton" destination="408" id="493"/>
+                <outlet property="touchIDEnabled" destination="Hs8-Tc-ezo" id="eqF-wX-rvg"/>
                 <outlet property="touchIdButton" destination="mQA-C0-JyU" id="fM3-PG-1OB"/>
+                <outlet property="touchIdEnabled" destination="Hs8-Tc-ezo" id="9Go-LQ-mSw"/>
                 <outlet property="unlockButton" destination="2" id="ZRr-Ui-ExP"/>
                 <outlet property="view" destination="1" id="143"/>
             </connections>
@@ -41,7 +43,7 @@
                     </pathCell>
                 </pathControl>
                 <imageView translatesAutoresizingMaskIntoConstraints="NO" id="262">
-                    <rect key="frame" x="230" y="305" width="48" height="48"/>
+                    <rect key="frame" x="230" y="312" width="48" height="48"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="48" id="273"/>
                         <constraint firstAttribute="width" constant="48" id="456"/>
@@ -49,7 +51,7 @@
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="02_MessageBoxWarningTemplate" id="263"/>
                 </imageView>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="268">
-                    <rect key="frame" x="199" y="281" width="110" height="16"/>
+                    <rect key="frame" x="199" y="288" width="110" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Wrong password!" id="269">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,12 +158,22 @@ DQ
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hs8-Tc-ezo">
+                    <rect key="frame" x="72" y="287" width="72" height="18"/>
+                    <buttonCell key="cell" type="check" title="TouchID" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="h3C-Z4-x7N">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="touchIdEnabledChanged:" target="-2" id="3pR-xA-wbI"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="262" firstAttribute="top" relation="greaterThanOrEqual" secondItem="1" secondAttribute="top" constant="20" symbolic="YES" id="276"/>
                 <constraint firstAttribute="centerX" secondItem="262" secondAttribute="centerX" id="286"/>
                 <constraint firstAttribute="centerY" secondItem="338" secondAttribute="centerY" id="386"/>
-                <constraint firstItem="338" firstAttribute="top" secondItem="268" secondAttribute="bottom" constant="8" symbolic="YES" id="400"/>
+                <constraint firstItem="338" firstAttribute="top" secondItem="268" secondAttribute="bottom" constant="15" id="400"/>
                 <constraint firstItem="268" firstAttribute="top" secondItem="262" secondAttribute="bottom" constant="8" symbolic="YES" id="402"/>
                 <constraint firstItem="408" firstAttribute="top" secondItem="338" secondAttribute="top" id="411"/>
                 <constraint firstItem="268" firstAttribute="centerX" secondItem="338" secondAttribute="centerX" id="447"/>
@@ -180,8 +192,10 @@ DQ
                 <constraint firstItem="txI-yI-5nE" firstAttribute="trailing" secondItem="241" secondAttribute="trailing" id="AVL-HO-SMq"/>
                 <constraint firstItem="17" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="EOa-K4-v7J"/>
                 <constraint firstItem="338" firstAttribute="leading" secondItem="d8O-Ha-rrS" secondAttribute="trailing" constant="8" symbolic="YES" id="KYs-Ia-SVl"/>
+                <constraint firstItem="Hs8-Tc-ezo" firstAttribute="leading" secondItem="d8O-Ha-rrS" secondAttribute="leading" id="MO7-cs-9KQ"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="tck-n8-s0U" secondAttribute="bottom" constant="20" symbolic="YES" id="Sny-FR-cY1"/>
                 <constraint firstItem="tck-n8-s0U" firstAttribute="trailing" secondItem="486" secondAttribute="trailing" id="UtJ-18-p5u"/>
+                <constraint firstItem="Hs8-Tc-ezo" firstAttribute="firstBaseline" secondItem="268" secondAttribute="firstBaseline" id="e94-Kz-Ohn"/>
                 <constraint firstItem="d8O-Ha-rrS" firstAttribute="centerY" secondItem="338" secondAttribute="centerY" id="kgB-jV-OGy"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="top" secondItem="241" secondAttribute="bottom" constant="8" symbolic="YES" id="lfg-eB-T2O"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="leading" secondItem="241" secondAttribute="leading" id="nGY-6Q-Vwy"/>

--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -16,7 +16,6 @@
                 <outlet property="messageInfoTextField" destination="268" id="ahE-sq-QzR"/>
                 <outlet property="passwordTextField" destination="338" id="495"/>
                 <outlet property="togglePasswordButton" destination="408" id="493"/>
-                <outlet property="touchIDEnabled" destination="Hs8-Tc-ezo" id="eqF-wX-rvg"/>
                 <outlet property="touchIdButton" destination="mQA-C0-JyU" id="fM3-PG-1OB"/>
                 <outlet property="touchIdEnabled" destination="Hs8-Tc-ezo" id="9Go-LQ-mSw"/>
                 <outlet property="unlockButton" destination="2" id="ZRr-Ui-ExP"/>

--- a/MacPass/Base.lproj/PasswordInputView.xib
+++ b/MacPass/Base.lproj/PasswordInputView.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -74,14 +75,14 @@
                     </connections>
                 </secureTextField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="408">
-                    <rect key="frame" x="357" y="251" width="33" height="23"/>
+                    <rect key="frame" x="357" y="251" width="32" height="23"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSQuickLookTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="409">
                         <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="486">
-                    <rect key="frame" x="357" y="221" width="33" height="23"/>
+                    <rect key="frame" x="357" y="221" width="32" height="23"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSStopProgressTemplate" imagePosition="only" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="487">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -98,7 +99,7 @@
                     </buttonCell>
                 </button>
                 <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tck-n8-s0U" userLabel="SubmitButtonContainer">
-                    <rect key="frame" x="166" y="176" width="223" height="20"/>
+                    <rect key="frame" x="164" y="176" width="224" height="20"/>
                     <subviews>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2pb-ZG-spA">
                             <rect key="frame" x="-7" y="-7" width="76" height="32"/>
@@ -124,7 +125,7 @@ Gw
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2">
-                            <rect key="frame" x="153" y="-7" width="77" height="32"/>
+                            <rect key="frame" x="153" y="-7" width="78" height="32"/>
                             <buttonCell key="cell" type="push" title="Unlock" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -151,7 +152,7 @@ DQ
                 <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="txI-yI-5nE">
                     <rect key="frame" x="157" y="204" width="195" height="14"/>
                     <textFieldCell key="cell" selectable="YES" title="key_file_warnig" id="f6J-5f-ZvP">
-                        <font key="font" metaFont="toolTip"/>
+                        <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -184,6 +185,7 @@ DQ
                 <constraint firstItem="486" firstAttribute="leading" secondItem="241" secondAttribute="trailing" constant="8" symbolic="YES" id="489"/>
                 <constraint firstItem="486" firstAttribute="leading" secondItem="408" secondAttribute="leading" id="490"/>
                 <constraint firstItem="408" firstAttribute="trailing" secondItem="486" secondAttribute="trailing" id="492"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hs8-Tc-ezo" secondAttribute="trailing" constant="20" symbolic="YES" id="4Zq-48-2fD"/>
                 <constraint firstItem="tck-n8-s0U" firstAttribute="top" secondItem="txI-yI-5nE" secondAttribute="bottom" constant="8" id="6tz-an-3SW"/>
                 <constraint firstItem="408" firstAttribute="leading" secondItem="338" secondAttribute="trailing" constant="8" symbolic="YES" id="7qE-8F-QgB"/>
                 <constraint firstItem="txI-yI-5nE" firstAttribute="trailing" secondItem="241" secondAttribute="trailing" id="AVL-HO-SMq"/>

--- a/MacPass/MPConstants.h
+++ b/MacPass/MPConstants.h
@@ -40,4 +40,11 @@ FOUNDATION_EXPORT NSString *const MPPluginUTI;
 FOUNDATION_EXPORT NSString *const MPBundleHelpURLKey;
 FOUNDATION_EXPORT NSString *const MPBundlePluginRepositoryURLKey;
 FOUNDATION_EXPORT NSString *const MPPluginCompatibilityURLKey;
+
+/**
+ Keychain Keys
+ */
+extern NSString *const TouchIdUnlockPublicKeyTag;
+extern NSString *const TouchIdUnlockPrivateKeyTag;
+
 #endif

--- a/MacPass/MPConstants.m
+++ b/MacPass/MPConstants.m
@@ -31,3 +31,6 @@ NSString *const MPBundleHelpURLKey                = @"MPHelpURL";
 NSString *const MPBundlePluginRepositoryURLKey    = @"MPPluginRepositoryURL";
 NSString *const MPPluginCompatibilityURLKey  = @"MPPluginCompatibilityURLKey";
 
+NSString *const TouchIdUnlockPublicKeyTag = @"com.hicknhacksoftware.macpass.publickey";
+NSString *const TouchIdUnlockPrivateKeyTag = @"com.hicknhacksoftware.macpass.privatekey";
+

--- a/MacPass/MPDocument.h
+++ b/MacPass/MPDocument.h
@@ -108,13 +108,13 @@ FOUNDATION_EXPORT NSString *const MPDocumentGroupKey;
 /**
  *  Decrypts the database with the given password and keyfile
  *
- *  @param password   The password to unlock the db with, can be nil. This is not the same as an empty string @""
- *  @param keyFileURL URL for the keyfile to use, can be nil
+ *  @param compositeKey   The CompositeKey to unlock the db.
+ *  @param keyFileURL URL for the keyfile that was used to create the compositeKey. Can be nil.
  *  @param error  Pointer to an NSError pointer of error reporting.
  *
  *  @return YES if the document was unlocked sucessfully, NO otherwise. Consult the error object for details
  */
-- (BOOL)unlockWithPassword:(NSString *)password keyFileURL:(NSURL *)keyFileURL error:(NSError *__autoreleasing*)error;
+- (BOOL)unlockWithPassword:(KPKCompositeKey *)compositeKey keyFileURL:(NSURL *)keyFileURL error:(NSError *__autoreleasing*)error;
 /**
  *  Changes the password of the database. Some sanity checks are applied and the change is aborted if the new values aren't valid
  *

--- a/MacPass/MPDocument.m
+++ b/MacPass/MPDocument.m
@@ -436,7 +436,7 @@ NSString *const MPDocumentGroupKey                            = @"MPDocumentGrou
                                           }
                                           // just return yes regardless since we will display the sheet again if needed!
                                           return YES;
-                                        } forFile:nil];
+                                        }];
       sheet.contentViewController = passwordInputController;
       [self.windowForSheet beginSheet:sheet completionHandler:^(NSModalResponse returnCode) { /* nothing to do, rest is done in other handler! */ }];
     }

--- a/MacPass/MPDocument.m
+++ b/MacPass/MPDocument.m
@@ -429,7 +429,7 @@ NSString *const MPDocumentGroupKey                            = @"MPDocumentGrou
       MPPasswordInputController *passwordInputController = [[MPPasswordInputController alloc] init];
       [passwordInputController requestPasswordWithMessage:NSLocalizedString(@"EXTERN_CHANGE_OF_MASTERKEY", @"The master key was changed by an external program!")
                                               cancelLabel:NSLocalizedString(@"ABORT_MERGE_KEEP_MINE", @"Button label to abort a merge on a file with changed master key!")
-                                        completionHandler:^BOOL(NSString *password, NSURL *keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
+                                        completionHandler:^BOOL(KPKCompositeKey *compositeKey, NSURL* keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
                                           [self.windowForSheet endSheet:sheet returnCode:(didCancel ? NSModalResponseCancel : NSModalResponseOK)];
                                           if(!didCancel) {
                                             NSData *keyFileData = keyURL ? [NSData dataWithContentsOfURL:keyURL] : nil;
@@ -501,7 +501,7 @@ NSString *const MPDocumentGroupKey                            = @"MPDocumentGrou
 }
 
 
-- (BOOL)unlockWithPassword:(NSString *)password keyFileURL:(NSURL *)keyFileURL error:(NSError *__autoreleasing*)error{
+- (BOOL)unlockWithPassword:(KPKCompositeKey *)compositeKey keyFileURL:(NSURL *)keyFileURL error:(NSError *__autoreleasing*)error{
   // TODO: Make this API asynchronous
   NSData *keyFileData = keyFileURL ? [NSData dataWithContentsOfURL:keyFileURL] : nil;
   

--- a/MacPass/MPDocument.m
+++ b/MacPass/MPDocument.m
@@ -432,10 +432,6 @@ NSString *const MPDocumentGroupKey                            = @"MPDocumentGrou
                                         completionHandler:^BOOL(KPKCompositeKey *compositeKey, NSURL* keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
                                           [self.windowForSheet endSheet:sheet returnCode:(didCancel ? NSModalResponseCancel : NSModalResponseOK)];
                                           if(!didCancel) {
-                                            NSData *keyFileData = keyURL ? [NSData dataWithContentsOfURL:keyURL] : nil;
-                                            KPKCompositeKey *compositeKey = [[KPKCompositeKey alloc] init];
-                                            [compositeKey addKey:[KPKKey keyWithPassword:password]];
-                                            [compositeKey addKey:[KPKKey keyWithKeyFileData:keyFileData]];
                                             [self _mergeWithContentsFromURL:url key:compositeKey options:options];
                                           }
                                           // just return yes regardless since we will display the sheet again if needed!
@@ -503,11 +499,7 @@ NSString *const MPDocumentGroupKey                            = @"MPDocumentGrou
 
 - (BOOL)unlockWithPassword:(KPKCompositeKey *)compositeKey keyFileURL:(NSURL *)keyFileURL error:(NSError *__autoreleasing*)error{
   // TODO: Make this API asynchronous
-  NSData *keyFileData = keyFileURL ? [NSData dataWithContentsOfURL:keyFileURL] : nil;
-  
-  self.compositeKey = [[KPKCompositeKey alloc] init];
-  [self.compositeKey addKey:[KPKKey keyWithPassword:password]];
-  [self.compositeKey addKey:[KPKKey keyWithKeyFileData:keyFileData]];
+  self.compositeKey = compositeKey;
   self.tree = [[KPKTree alloc] initWithData:self.encryptedData key:self.compositeKey error:error];
   
   BOOL isUnlocked = (nil != self.tree);

--- a/MacPass/MPDocument.m
+++ b/MacPass/MPDocument.m
@@ -440,7 +440,7 @@ NSString *const MPDocumentGroupKey                            = @"MPDocumentGrou
                                           }
                                           // just return yes regardless since we will display the sheet again if needed!
                                           return YES;
-                                        }];
+                                        } forFile:nil];
       sheet.contentViewController = passwordInputController;
       [self.windowForSheet beginSheet:sheet completionHandler:^(NSModalResponse returnCode) { /* nothing to do, rest is done in other handler! */ }];
     }

--- a/MacPass/MPDocumentWindowController.m
+++ b/MacPass/MPDocumentWindowController.m
@@ -325,16 +325,12 @@ typedef void (^MPPasswordChangedBlock)(BOOL didChangePassword);
     self.passwordInputController = [[MPPasswordInputController alloc] init];
   }
   self.contentViewController = self.passwordInputController;
-  NSURL* fileURL = nil;
-  if(self.document != nil) {
-    fileURL = [self.document fileURL];
-  }
   [self.passwordInputController requestPasswordWithMessage:message cancelLabel:nil completionHandler:^BOOL(KPKCompositeKey* compositeKey, NSURL* keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
     if(didCancel) {
       return NO;
     }
     return [((MPDocument *)self.document) unlockWithPassword:compositeKey keyFileURL:keyURL error:error ];
-  } forFile:fileURL];
+  }];
 }
 
 - (void)editPassword:(id)sender {

--- a/MacPass/MPDocumentWindowController.m
+++ b/MacPass/MPDocumentWindowController.m
@@ -329,12 +329,11 @@ typedef void (^MPPasswordChangedBlock)(BOOL didChangePassword);
   if(self.document != nil) {
     fileURL = [self.document fileURL];
   }
-  [self.passwordInputController requestPasswordWithMessage:message cancelLabel:nil completionHandler:^BOOL(NSString *password, NSURL *keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
+  [self.passwordInputController requestPasswordWithMessage:message cancelLabel:nil completionHandler:^BOOL(KPKCompositeKey* compositeKey, NSURL* keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
     if(didCancel) {
       return NO;
     }
-    return [((MPDocument *)self.document) unlockWithPassword:password keyFileURL:keyURL error:error];
-    
+    return [((MPDocument *)self.document) unlockWithPassword:compositeKey keyFileURL:keyURL error:error ];
   } forFile:fileURL];
 }
 

--- a/MacPass/MPDocumentWindowController.m
+++ b/MacPass/MPDocumentWindowController.m
@@ -325,13 +325,17 @@ typedef void (^MPPasswordChangedBlock)(BOOL didChangePassword);
     self.passwordInputController = [[MPPasswordInputController alloc] init];
   }
   self.contentViewController = self.passwordInputController;
+  NSURL* fileURL = nil;
+  if(self.document != nil) {
+    fileURL = [self.document fileURL];
+  }
   [self.passwordInputController requestPasswordWithMessage:message cancelLabel:nil completionHandler:^BOOL(NSString *password, NSURL *keyURL, BOOL didCancel, NSError *__autoreleasing *error) {
     if(didCancel) {
       return NO;
     }
     return [((MPDocument *)self.document) unlockWithPassword:password keyFileURL:keyURL error:error];
     
-  }];
+  } forFile:fileURL];
 }
 
 - (void)editPassword:(id)sender {

--- a/MacPass/MPIntegrationPreferencesController.m
+++ b/MacPass/MPIntegrationPreferencesController.m
@@ -24,6 +24,7 @@
 #import "MPSettingsHelper.h"
 #import "MPIconHelper.h"
 #import "MPAutotypeDoctor.h"
+#import "MPConstants.h"
 
 #import "DDHotKeyCenter.h"
 #import "DDHotKey+MacPassAdditions.h"
@@ -128,5 +129,33 @@
 
 - (void)runAutotypeDoctor:(id)sender {
   [MPAutotypeDoctor.defaultDoctor runChecksAndPresentResults];
+}
+
+#pragma mark -
+#pragma mark Keychain Actions
+- (IBAction)RenewTouchIdKey:(id)sender {
+    NSData* publicKeyTag = [TouchIdUnlockPublicKeyTag dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *publicKeyQuery = @{
+      (id)kSecClass: (id)kSecClassKey,
+      (id)kSecAttrApplicationTag: publicKeyTag,
+      (id)kSecReturnRef: @YES,
+    };
+    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)publicKeyQuery);
+    if (status != errSecSuccess) {
+        NSString* description = (__bridge NSString*)SecCopyErrorMessageString(status, NULL);
+        NSLog(@"Error while trying to delete public key from Keychain: %@", description);
+    }
+    
+    NSData* privateKeyTag = [TouchIdUnlockPrivateKeyTag dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *privateKeyQuery = @{
+      (id)kSecClass: (id)kSecClassKey,
+      (id)kSecAttrApplicationTag: privateKeyTag,
+      (id)kSecReturnRef: @YES,
+    };
+    status = SecItemDelete((__bridge CFDictionaryRef)privateKeyQuery);
+    if (status != errSecSuccess) {
+        NSString* description = (__bridge NSString*)SecCopyErrorMessageString(status, NULL);
+        NSLog(@"Error while trying to delete private key from Keychain: %@", description);
+    }
 }
 @end

--- a/MacPass/MPPasswordInputController.h
+++ b/MacPass/MPPasswordInputController.h
@@ -29,7 +29,7 @@
 
 typedef BOOL (^passwordInputCompletionBlock)(KPKCompositeKey *key, NSURL* keyFileURL, BOOL didCancel, NSError *__autoreleasing*error);
 
-- (void)requestPasswordWithMessage:(NSString *)message cancelLabel:(NSString *)cancelLabel completionHandler:(passwordInputCompletionBlock)completionHandler forFile:(NSURL*) fileURL;
+- (void)requestPasswordWithMessage:(NSString *)message cancelLabel:(NSString *)cancelLabel completionHandler:(passwordInputCompletionBlock)completionHandler;
 
 
 @end

--- a/MacPass/MPPasswordInputController.h
+++ b/MacPass/MPPasswordInputController.h
@@ -21,12 +21,13 @@
 //
 
 #import "MPViewController.h"
+#import "KeePassKit/KeePassKit.h"
 
 @class KPKCompositeKey;
 
 @interface MPPasswordInputController : MPViewController <NSTouchBarDelegate>
 
-typedef BOOL (^passwordInputCompletionBlock)(NSString *password, NSURL *keyURL, BOOL didCancel, NSError *__autoreleasing*error);
+typedef BOOL (^passwordInputCompletionBlock)(KPKCompositeKey *key, NSURL* keyFileURL, BOOL didCancel, NSError *__autoreleasing*error);
 
 - (void)requestPasswordWithMessage:(NSString *)message cancelLabel:(NSString *)cancelLabel completionHandler:(passwordInputCompletionBlock)completionHandler forFile:(NSURL*) fileURL;
 

--- a/MacPass/MPPasswordInputController.h
+++ b/MacPass/MPPasswordInputController.h
@@ -28,8 +28,7 @@
 
 typedef BOOL (^passwordInputCompletionBlock)(NSString *password, NSURL *keyURL, BOOL didCancel, NSError *__autoreleasing*error);
 
-- (void)requestPasswordWithCompletionHandler:(passwordInputCompletionBlock)completionHandler;
-- (void)requestPasswordWithMessage:(NSString *)message cancelLabel:(NSString *)cancelLabel completionHandler:(passwordInputCompletionBlock)completionHandler;
+- (void)requestPasswordWithMessage:(NSString *)message cancelLabel:(NSString *)cancelLabel completionHandler:(passwordInputCompletionBlock)completionHandler forFile:(NSURL*) fileURL;
 
 
 @end

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -27,6 +27,7 @@
 #import "MPSettingsHelper.h"
 #import "MPPathControl.h"
 #import "MPTouchBarButtonCreator.h"
+#import "MPSettingsHelper.h"
 
 #import "HNHUi/HNHUi.h"
 
@@ -47,6 +48,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
 @property (weak) IBOutlet NSButton *unlockButton;
 @property (weak) IBOutlet NSButton *cancelButton;
 @property (weak) IBOutlet NSButton *touchIdButton;
+@property (weak) IBOutlet NSButton *touchIdEnabled;
 
 @property (copy) NSString *message;
 @property (copy) NSString *cancelLabel;
@@ -88,6 +90,11 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   [self.enablePasswordCheckBox bind:NSValueBinding toObject:self withKeyPath:NSStringFromSelector(@selector(enablePassword)) options:nil];
   [self.togglePasswordButton bind:NSEnabledBinding toObject:self withKeyPath:NSStringFromSelector(@selector(enablePassword)) options:nil];
   [self.passwordTextField bind:NSEnabledBinding toObject:self withKeyPath:NSStringFromSelector(@selector(enablePassword)) options:nil];
+  self.touchIdEnabled.hidden = true;
+  if (@available(macOS 10.13.4, *)) {
+    self.touchIdEnabled.hidden = false;
+    self.touchIdEnabled.state = [NSUserDefaults.standardUserDefaults boolForKey:kMPSettingsKeyEntryTouchIdEnabled];
+  }
   [self _reset];
 }
 
@@ -142,7 +149,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   BOOL cancel = (sender == self.cancelButton);
   BOOL result = self.completionHandler(password, self.keyPathControl.URL, cancel, &error);
   if(cancel || result) {
-    if(result && self.keyPathControl.URL == nil) {
+    if(result && self.keyPathControl.URL == nil && self.touchIdEnabled.state) {
       [self _storePasswordForTouchIDUnlock:password forDatabase:self.absoluteURLString];
     }
     return;
@@ -306,6 +313,9 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   else {
     self.keyPathControl.URL = nil;
   }
+}
+- (IBAction)touchIdEnabledChanged:(id)sender {
+    [NSUserDefaults.standardUserDefaults setBool:self.touchIdEnabled.state forKey:kMPSettingsKeyEntryTouchIdEnabled];
 }
 
 - (void)_reset {

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -28,6 +28,7 @@
 #import "MPPathControl.h"
 #import "MPTouchBarButtonCreator.h"
 #import "MPSettingsHelper.h"
+#import "MPConstants.h"
 
 #import "HNHUi/HNHUi.h"
 
@@ -175,8 +176,8 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   CFErrorRef error = NULL;
   NSString* publicKeyLabel =  @"MacPass TouchID Feature Public Key";
   NSString* privateKeyLabel = @"MacPass TouchID Feature Private Key";
-  NSData* publicKeyTag =  [@"com.hicknhacksoftware.macpass.publickey"  dataUsingEncoding:NSUTF8StringEncoding];
-  NSData* privateKeyTag = [@"com.hicknhacksoftware.macpass.privatekey" dataUsingEncoding:NSUTF8StringEncoding];
+  NSData* publicKeyTag =  [TouchIdUnlockPublicKeyTag  dataUsingEncoding:NSUTF8StringEncoding];
+  NSData* privateKeyTag = [TouchIdUnlockPrivateKeyTag dataUsingEncoding:NSUTF8StringEncoding];
   SecAccessControlRef access = NULL;
   if (@available(macOS 10.13.4, *)) {
     SecAccessControlCreateFlags flags = kSecAccessControlBiometryCurrentSet;
@@ -228,7 +229,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
 - (NSData*) _touchIdEncryptCompositeKey: (KPKCompositeKey*) compositeKey {
   NSData* encryptedKey = nil;
   NSData* keyData = [NSKeyedArchiver archivedDataWithRootObject:compositeKey];
-  NSData* tag = [@"com.hicknhacksoftware.macpass.publickey" dataUsingEncoding:NSUTF8StringEncoding];
+  NSData* tag = [TouchIdUnlockPublicKeyTag dataUsingEncoding:NSUTF8StringEncoding];
   NSDictionary *getquery = @{
     (id)kSecClass: (id)kSecClassKey,
     (id)kSecAttrApplicationTag: tag,
@@ -265,7 +266,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
 - (KPKCompositeKey*) _touchIdDecryptCompositeKey: (NSData*) encryptedKey {
   KPKCompositeKey* result = nil;
   if(encryptedKey != nil) {
-    NSData* tag = [@"com.hicknhacksoftware.macpass.privatekey" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData* tag = [TouchIdUnlockPrivateKeyTag dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *queryPrivateKey = @{
       (id)kSecClass: (id)kSecClassKey,
       (id)kSecAttrApplicationTag: tag,
@@ -332,6 +333,9 @@ static NSMutableDictionary* touchIDSecuredPasswords;
     NSError* error;
     self.completionHandler(compositeKey, nil, false, &error);
     [self _showError:error];
+  }
+  else {
+    self.touchIdButton.hidden = true;
   }
 }
 

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -175,9 +175,13 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   NSData* privateKeyTag = [@"com.hicknhacksoftware.macpass.privatekey" dataUsingEncoding:NSUTF8StringEncoding];
   SecAccessControlRef access = NULL;
   if (@available(macOS 10.13.4, *)) {
+    SecAccessControlCreateFlags flags = kSecAccessControlBiometryCurrentSet;
+    if (@available(macOS 10.15, *)) {
+      flags |= kSecAccessControlWatch | kSecAccessControlOr;
+    }
     access = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
                                              kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-                                             kSecAccessControlBiometryCurrentSet,
+                                             flags,
                                              &error);
     if(access == NULL) {
       NSError *err = CFBridgingRelease(error);

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -140,7 +140,11 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   BOOL cancel = (sender == self.cancelButton);
   NSURL* keyURL = self.keyPathControl.URL;
   NSData *keyFileData = keyURL ? [NSData dataWithContentsOfURL:keyURL] : nil;
-  KPKCompositeKey *compositeKey = [[KPKCompositeKey alloc] initWithPassword:password keyFileData:keyFileData];
+  KPKKey* passwordKey = [KPKKey keyWithPassword:password];
+  KPKKey* fileKey = [KPKKey keyWithKeyFileData:keyFileData];
+  KPKCompositeKey* compositeKey = [[KPKCompositeKey alloc] init];
+  [compositeKey addKey:passwordKey];
+  [compositeKey addKey:fileKey];
   BOOL result = self.completionHandler(compositeKey, keyURL, cancel, &error);
   [self _touchIdHandleUnlockAttempt:compositeKey withResult:result];
   if(cancel || result) {

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -95,6 +95,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   if (@available(macOS 10.13.4, *)) {
     self.touchIdEnabled.hidden = false;
     self.touchIdEnabled.state = [NSUserDefaults.standardUserDefaults integerForKey:kMPSettingsKeyEntryTouchIdEnabled];
+    [self _updateTouchIdTooltip];
   }
   [self _reset];
 }
@@ -341,6 +342,19 @@ static NSMutableDictionary* touchIDSecuredPasswords;
 
 - (IBAction)touchIdEnabledChanged:(id)sender {
     [NSUserDefaults.standardUserDefaults setInteger: self.touchIdEnabled.state forKey:kMPSettingsKeyEntryTouchIdEnabled];
+  [self _updateTouchIdTooltip];
+}
+
+- (void) _updateTouchIdTooltip {
+  if(self.touchIdEnabled.state == NSControlStateValueOn) {
+    self.touchIdEnabled.toolTip = @"Unlocking via TouchID is enabled";
+  }
+  else if(self.touchIdEnabled.state == NSControlStateValueOff) {
+    self.touchIdEnabled.toolTip = @"Unlocking via TouchID is disabled";
+  }
+  else {
+    self.touchIdEnabled.toolTip = @"Unlocking via TouchID is possible until MacPass is restarted";
+  }
 }
 
 - (IBAction)resetKeyFile:(id)sender {

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -234,7 +234,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
       }
     }
     else {
-      NSLog(@"The password is to large to be encrypted");
+      NSLog(@"The password is too large to be encrypted");
       return;
     }
   }
@@ -269,7 +269,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
           }
           else {
             NSError *err = CFBridgingRelease(error);
-            NSLog(@"Error while trying decrypt password for TouchID unlock: %@", [err description]);
+            NSLog(@"Error while trying to decrypt password for TouchID unlock: %@", [err description]);
           }
         }
         else {

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -29,6 +29,7 @@
 #import "MPTouchBarButtonCreator.h"
 #import "MPSettingsHelper.h"
 #import "MPConstants.h"
+#import "MPSettingsHelper.h"
 
 #import "HNHUi/HNHUi.h"
 
@@ -90,10 +91,11 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   [self.enablePasswordCheckBox bind:NSValueBinding toObject:self withKeyPath:NSStringFromSelector(@selector(enablePassword)) options:nil];
   [self.togglePasswordButton bind:NSEnabledBinding toObject:self withKeyPath:NSStringFromSelector(@selector(enablePassword)) options:nil];
   [self.passwordTextField bind:NSEnabledBinding toObject:self withKeyPath:NSStringFromSelector(@selector(enablePassword)) options:nil];
+  NSUserDefaultsController *defaultsController = [NSUserDefaultsController sharedUserDefaultsController];
+  [self.touchIdEnabledButton bind:NSValueBinding toObject:defaultsController withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyEntryTouchIdEnabled] options:nil];
   self.touchIdEnabledButton.hidden = true;
   if (@available(macOS 10.13.4, *)) {
     self.touchIdEnabledButton.hidden = false;
-    self.touchIdEnabledButton.state = [NSUserDefaults.standardUserDefaults integerForKey:kMPSettingsKeyEntryTouchIdEnabled];
     [self _touchIdUpdateToolTip];
   }
   [self _reset];
@@ -371,12 +373,11 @@ static NSMutableDictionary* touchIDSecuredPasswords;
   if(success) {
     return;
   }
-  [self.touchIdEnabledButton setEnabled:false];
+  [self.touchIdButton setEnabled:false];
   [self _showError:error];
 }
 
 - (IBAction)touchIdEnabledChanged:(id)sender {
-  [NSUserDefaults.standardUserDefaults setInteger: self.touchIdEnabledButton.state forKey:kMPSettingsKeyEntryTouchIdEnabled];
   [self _touchIdUpdateToolTip];
 }
 

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -348,14 +348,14 @@
 }
 
 - (void) _touchIdUpdateToolTip {
-  if(self.touchIdEnabledButton.state == NSControlStateValueOn) {
-    self.touchIdEnabledButton.toolTip = @"Unlocking via TouchID is enabled";
-  }
-  else if(self.touchIdEnabledButton.state == NSControlStateValueOff) {
-    self.touchIdEnabledButton.toolTip = @"Unlocking via TouchID is disabled";
-  }
-  else {
-    self.touchIdEnabledButton.toolTip = @"Unlocking via TouchID is possible until MacPass is restarted";
+  switch(self.touchIdEnabledButton.state) {
+    case NSControlStateValueOn:
+      self.touchIdEnabledButton.toolTip = NSLocalizedString(@"TOOLTIP_TOUCHID_ENABELD", @"Tooltip displayed when TouchID is is fully enabeld");
+    case NSControlStateValueOff:
+      self.touchIdEnabledButton.toolTip = NSLocalizedString(@"TOOLTIP_TOUCHID_DISABLED", @"Tooltip displayed when TouchID is disabled");
+    case NSControlStateValueMixed:
+    default:
+      self.touchIdEnabledButton.toolTip = NSLocalizedString(@"TOOLTIP_TOUCHID_TRANSIENT", @"Tooltip displayed when TouchID is in transient (inmemory) mode");
   }
 }
 

--- a/MacPass/MPPasswordInputController.m
+++ b/MacPass/MPPasswordInputController.m
@@ -244,7 +244,7 @@ static NSMutableDictionary* touchIDSecuredPasswords;
     encryptedKey = (NSData*)CFBridgingRelease(SecKeyCreateEncryptedData(publicKey, algorithm, (__bridge CFDataRef)keyData, &error));
     if (!encryptedKey) {
       NSError *err = CFBridgingRelease(error);
-      NSLog(@"Error while trying decrypt password for TouchID unlock: %@", [err description]);
+      NSLog(@"Error while trying to decrypt the CompositeKey for TouchID unlock: %@", [err description]);
     }
   }
   else {

--- a/MacPass/MPSettingsHelper.h
+++ b/MacPass/MPSettingsHelper.h
@@ -22,6 +22,9 @@
 
 #import <Cocoa/Cocoa.h>
 
+/* TouchID */
+APPKIT_EXTERN NSString *const kMPSettingsKeyEntryTouchIdEnabled;
+
 /* Clipboard */
 APPKIT_EXTERN NSString *const kMPSettingsKeyPasteboardClearTimeout;
 APPKIT_EXTERN NSString *const kMPSettingsKeyClearPasteboardOnQuit;

--- a/MacPass/MPSettingsHelper.h
+++ b/MacPass/MPSettingsHelper.h
@@ -24,6 +24,7 @@
 
 /* TouchID */
 APPKIT_EXTERN NSString *const kMPSettingsKeyEntryTouchIdEnabled;
+APPKIT_EXTERN NSString *const kMPSettingsKeyEntryTouchIdDatabaseEncryptedKeyFormat;
 
 /* Clipboard */
 APPKIT_EXTERN NSString *const kMPSettingsKeyPasteboardClearTimeout;

--- a/MacPass/MPSettingsHelper.m
+++ b/MacPass/MPSettingsHelper.m
@@ -63,6 +63,7 @@ NSString *const kMPSettingsKeyAutotypeMatchTags                           = @"Au
 NSString *const kMPSettingsKeyGloablAutotypeAlwaysShowCandidateSelection  = @"GloablAutotypeAlwaysShowCandidateSelection";
 
 NSString *const kMPSettingsKeyEntryTouchIdEnabled                     = @"EnableSubsequentUnlocksWithTouchID";
+NSString *const kMPSettingsKeyEntryTouchIdDatabaseEncryptedKeyFormat  = @"EncryptedDatabaseKeyForTouchID-%@";
 
 NSString *const kMPSettingsKeyEntrySearchFilterContext                    = @"EntrySearchFilterContext";
 

--- a/MacPass/MPSettingsHelper.m
+++ b/MacPass/MPSettingsHelper.m
@@ -62,6 +62,8 @@ NSString *const kMPSettingsKeyAutotypeMatchHost                           = @"Au
 NSString *const kMPSettingsKeyAutotypeMatchTags                           = @"AutotypeMatchTags";
 NSString *const kMPSettingsKeyGloablAutotypeAlwaysShowCandidateSelection  = @"GloablAutotypeAlwaysShowCandidateSelection";
 
+NSString *const kMPSettingsKeyEntryTouchIdEnabled                     = @"EnableSubsequentUnlocksWithTouchID";
+
 NSString *const kMPSettingsKeyEntrySearchFilterContext                    = @"EntrySearchFilterContext";
 
 NSString *const kMPSettingsKeyEnableQuicklookPreview                      = @"EnableQuicklookPreview";

--- a/MacPass/MPTouchIdCompositeKeyStore.h
+++ b/MacPass/MPTouchIdCompositeKeyStore.h
@@ -1,0 +1,21 @@
+//
+//  MPTouchIdCompositeKeyStore.h
+//  MacPass
+//
+//  Created by Julius Zint on 14.03.21.
+//  Copyright © 2021 HicknHack Software GmbH. All rights reserved.
+//
+
+#ifndef MPTouchIdCompositeKeyStore_h
+#define MPTouchIdCompositeKeyStore_h
+
+static NSMutableDictionary* touchIDSecuredPasswords;
+
+@interface MPTouchIdCompositeKeyStore : NSObject
+  @property (class, strong, readonly) MPTouchIdCompositeKeyStore *defaultStore;
+
+  - (void) save:(NSData*) encryptedCompositeKey forDocumentKey:(NSString*) documentKey;
+  - (bool) load:(NSData**) encryptedCompositeKey forDocumentKey:(NSString*) documentKey;
+@end
+
+#endif /* MPTouchIdCompositeKeyStore_h */

--- a/MacPass/MPTouchIdCompositeKeyStore.m
+++ b/MacPass/MPTouchIdCompositeKeyStore.m
@@ -1,0 +1,64 @@
+//
+//  MPTouchIdCompositeKeyStore.m
+//  MacPass
+//
+//  Created by Julius Zint on 14.03.21.
+//  Copyright © 2021 HicknHack Software GmbH. All rights reserved.
+//
+#import "MPSettingsHelper.h"
+#import "MPTouchIdCompositeKeyStore.h"
+
+@implementation MPTouchIdCompositeKeyStore
+
++ (instancetype)defaultStore {
+  static MPTouchIdCompositeKeyStore *instance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    instance = [[MPTouchIdCompositeKeyStore alloc] init];
+    if(touchIDSecuredPasswords == NULL) {
+      touchIDSecuredPasswords = [[NSMutableDictionary alloc]init];
+    }
+  });
+  return instance;
+}
+
+- (void) save: (NSData*) encryptedCompositeKey forDocumentKey:(NSString*) documentKey {
+  long touchIdMode = [NSUserDefaults.standardUserDefaults integerForKey:kMPSettingsKeyEntryTouchIdEnabled];
+  if (touchIdMode == NSControlStateValueMixed) {
+    [NSUserDefaults.standardUserDefaults removeObjectForKey:documentKey];
+    if(encryptedCompositeKey != NULL) {
+      [touchIDSecuredPasswords setObject:encryptedCompositeKey forKey:documentKey];
+    }
+  }
+  else if(touchIdMode == NSControlStateValueOn) {
+    [touchIDSecuredPasswords removeObjectForKey:documentKey];
+    if(encryptedCompositeKey != NULL) {
+      [NSUserDefaults.standardUserDefaults setObject:encryptedCompositeKey forKey:documentKey];
+    }
+  }
+  else {
+    [NSUserDefaults.standardUserDefaults removeObjectForKey:documentKey];
+    [touchIDSecuredPasswords removeObjectForKey:documentKey];
+  }
+}
+
+- (bool) load: (NSData**) encryptedCompositeKey forDocumentKey: (NSString*) documentKey {
+  long touchIdMode = [NSUserDefaults.standardUserDefaults integerForKey:kMPSettingsKeyEntryTouchIdEnabled];
+  NSData* transientKey  = [touchIDSecuredPasswords valueForKey:documentKey];
+  NSData* persistentKey =[NSUserDefaults.standardUserDefaults dataForKey:documentKey];
+  if(transientKey == NULL && persistentKey == NULL) {
+    return false;
+  }
+  if(transientKey == NULL || persistentKey == NULL) {
+    *encryptedCompositeKey = transientKey == NULL ? persistentKey : transientKey;
+    return true;
+  }
+  if(touchIdMode == NSControlStateValueOn) {
+    *encryptedCompositeKey = persistentKey;
+    return true;
+  }
+  *encryptedCompositeKey = transientKey;
+  return true;
+}
+
+@end

--- a/MacPass/MacPass.entitlements
+++ b/MacPass/MacPass.entitlements
@@ -7,6 +7,8 @@
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 	<key>keychain-access-groups</key>
-	<array/>
+  <array>
+    <string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
 </dict>
 </plist>

--- a/MacPass/MacPass.entitlements
+++ b/MacPass/MacPass.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
### Feature
This patch enables MacPass users to unlock their KeePass containers with TouchID. In contrast to #638,  the implementation does not store the master password directly into the keychain of macOS. Instead it creates a RSA 2048 key pair and uses the public key to encrypt the password. The encrypted password is then kept in memory as long as the MacPass process is alive.

The private key is then used on a subsequent unlock to decrypt the master password. macOS will only return the private key if the device is unlocked and a user, who`s fingerprints were enrolled at the time the key pair was created, authenticates via TouchID.

On every launch of MacPass the user has to supply the master password once for TouchID unlock to work. This is a trade of between security and convenience. But on macOS system restarts are fewer than on windows and the MacPass process stays alive, even if all windows are closed.

### Todo
1. - [x] `SecKeyGeneratePair` returns with the error: `Required entitlement isn't present` if the `Keychain Sharing` capability is not enabled. For this reason i tested most of this code in a small test project with this capability enabled. For testing in MacPass i commented out this [line](https://github.com/juliuszint/MacPass/blob/7c6a4d9bc4d625bbf25ad1a317209f38836e22c7/MacPass/MPPasswordInputController.m#L175). With this change the key is created successfully even if the entitlement is not set. This is only for testing purposes since the user is not prompted for authentication via TouchID.
**In short**: it would be great if someone could enable this entitlement and build a signed version to actually verify it.

2. - [x] The used dictionary supports storing passwords for multiple KeePass databases. Right now the constant key `@DatabaseID` is used and needs to be replaced in order to support multiple databases.

3. - [x] I have no prior experience programming in Objective-C. So a very detailed code review would be appreciated especially concerning memory management. The bulk of the new code is around 150 lines so it should not be too time consuming.

4.  - [x] `static` variables are often viewed as bad practice. i am open to changing this to something that gets injected. For the first pull request this was the easiest way. 