### PR TITLE
Update organization in GitHub URL

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
-MacPass, a KeePass compatible Password Manager for OS X 
+MacPass, a KeePass compatible Password Manager for OS X
 Copyright (C) 2012-2016  Michael Starke, and all MacPass contributors
 A full list of contributors can be found at
-<https://github.com/mstarke/MacPass/graphs/contributors>
+<https://github.com/MacPass/MacPass/graphs/contributors>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/MacPass/Base.lproj/Credits.rtf
+++ b/MacPass/Base.lproj/Credits.rtf
@@ -10,11 +10,11 @@
 
 \f0\b\fs24 \cf2 Project Website:\cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://macpassapp.org"}}{\fldrslt 
+{\field{\*\fldinst{HYPERLINK "https://macpassapp.org"}}{\fldrslt
 \f1\b0 \cf2 macpassapp.org}}
 \f1\b0 \cf3 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://github.com/mstarke/MacPass"}}{\fldrslt \cf3 MacPass}} \cf2 on GitHub.\
+{\field{\*\fldinst{HYPERLINK "https://github.com/MacPass/MacPass"}}{\fldrslt \cf3 MacPass}} \cf2 on GitHub.\
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 
 \f0\b \cf2 \
@@ -40,7 +40,7 @@ You should have received a copy of the GNU General Public License along with thi
 \f0\b \cf0 \kerning1\expnd0\expndtw0 Sponsors:
 \f2\b0\fs52 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "mailto:dominik@roszkowski.dev"}}{\fldrslt 
+{\field{\*\fldinst{HYPERLINK "mailto:dominik@roszkowski.dev"}}{\fldrslt
 \f1\fs24 \cf0 \kerning1\expnd0\expndtw3
 Dominik Roszkowski}}
 \f1\fs24 \kerning1\expnd0\expndtw3
@@ -52,9 +52,9 @@ Dominik Roszkowski}}
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
 
 \f1\b0 \cf2 \
-Dutch translation: {\field{\*\fldinst{HYPERLINK "https://github.com/FrankKooij"}}{\fldrslt \cf3 Frank Kooij}}, 
+Dutch translation: {\field{\*\fldinst{HYPERLINK "https://github.com/FrankKooij"}}{\fldrslt \cf3 Frank Kooij}},
 \f3 \cf4 \expnd0\expndtw0\kerning0
- {\field{\*\fldinst{HYPERLINK "https://github.com/clone1612"}}{\fldrslt 
+ {\field{\*\fldinst{HYPERLINK "https://github.com/clone1612"}}{\fldrslt
 \f1 \cf3 \kerning1\expnd0\expndtw0 Jannick Hemelhof}}
 \f1 \cf0 \kerning1\expnd0\expndtw0 \
 \

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ MacPass is an attempt to create a native macOS port of KeePass on a solid open s
 
 ## Download
 
-All pre-built releases can be found at [Github](https://github.com/mstarke/MacPass/releases).
+All pre-built releases can be found at [Github](https://github.com/MacPass/MacPass/releases).
 
-An unsigned build of the current continuous tag can be found here: [Continuous Build](https://github.com/mstarke/MacPass/releases/tag/continuous)
+An unsigned build of the current continuous tag can be found here: [Continuous Build](https://github.com/MacPass/MacPass/releases/tag/continuous)
 
 Due to the nature of the build it might be unstable, however this version contains all the latest changes and bug fixes!
 
@@ -23,7 +23,7 @@ If you want to contribute by fixing a bug, adding a feature or improving localiz
 
 * Fetch the source of MacPass
 ```bash
-git clone https://github.com/mstarke/MacPass --recursive
+git clone https://github.com/MacPass/MacPass --recursive
 ```
 * Install [Carthage](https://github.com/Carthage/Carthage#installing-carthage)
 * Install all Dependencies
@@ -31,13 +31,13 @@ git clone https://github.com/mstarke/MacPass --recursive
 cd MacPass
 carthage bootstrap --platform macOS
 ```
-After that you can build and run in Xcode. The following command will build and make the application available through Spotlight. If you run into signing issues take a look at [Issue #92](https://github.com/mstarke/MacPass/issues/92). Since Sparkle is disabled only on the CI build and in Debug mode, you have to explicitly disable it in Release. Otherwise warnings on unsecure updates will appear.
+After that you can build and run in Xcode. The following command will build and make the application available through Spotlight. If you run into signing issues take a look at [Issue #92](https://github.com/MacPass/MacPass/issues/92). Since Sparkle is disabled only on the CI build and in Debug mode, you have to explicitly disable it in Release. Otherwise warnings on unsecure updates will appear.
 
     xcodebuild -scheme MacPass -target MacPass -configuration Release CODE_SIGNING_REQUIRED=NO NO_SPARKLE=NO_SPARKLE
 
 ## Help
 
-Some questions might be answered in the [FAQ](https://github.com/mstarke/MacPass/wiki/FAQ)
+Some questions might be answered in the [FAQ](https://github.com/MacPass/MacPass/wiki/FAQ)
 
 Another place to look is the IRC channel [#macpass](irc://irc.freenode.org/macpass) on [irc.freenode.org](irc://irc.freenode.org)
 
@@ -50,16 +50,16 @@ Earlier versions of MacPass require macOS 10.8 Mountain Lion or later.
 
 ## Status
 
-The Status can be found on the dedicated [Wiki page](https://github.com/mstarke/MacPass/wiki/Status).
+The Status can be found on the dedicated [Wiki page](https://github.com/MacPass/MacPass/wiki/Status).
 
 ## What does it look like?
 
 ![image](https://raw.github.com/mstarke/MacPass/master/Assets/Screenshots/MacPass.png)
 
-More Screenshots in the [Wiki](https://github.com/mstarke/MacPass/wiki/Screenshots)
+More Screenshots in the [Wiki](https://github.com/MacPass/MacPass/wiki/Screenshots)
 
 ## Alternatives
- 
+
 [KeePassX](https://www.keepassx.org) and its fork [KeePassXC](https://github.com/keepassxreboot/keepassxc). Qt based cross plattform port.
 
 [KyPass Companion](http://www.kyuran.be/logiciels/kypass4mac/). Native macOS client.
@@ -69,7 +69,7 @@ More Screenshots in the [Wiki](https://github.com/mstarke/MacPass/wiki/Screensho
 ## License
 
 MacPass, a KeePass compatible Password Manager for OS X
-Copyright (c) 2012-2017  Michael Starke (HicknHack Software GmbH) and all [MacPass contributors](https://github.com/mstarke/MacPass/graphs/contributors)
+Copyright (c) 2012-2017  Michael Starke (HicknHack Software GmbH) and all [MacPass contributors](https://github.com/MacPass/MacPass/graphs/contributors)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -92,7 +92,7 @@ For further details, take a look at the [explanation](https://www.fsf.org/news/2
 
 ## Contributions
 
-The following list might not be complete, please refer to [merged Pull Requests](https://github.com/mstarke/MacPass/pulls?utf8=✓&q=is%3Apr+is%3Aclosed+is%3Amerged) on GitHub for more details. Please open an issue if you think someone is missing from this list!
+The following list might not be complete, please refer to [merged Pull Requests](https://github.com/MacPass/MacPass/pulls?utf8=✓&q=is%3Apr+is%3Aclosed+is%3Amerged) on GitHub for more details. Please open an issue if you think someone is missing from this list!
 
 ### Art
 
@@ -183,17 +183,17 @@ The following list might not be complete, please refer to [merged Pull Requests]
 
 This Project is based upon the following work:
 
-[KeePassKit](https://github.com/mstarke/KeePassKit) Copyright 2012 HicknHack Software GmbH. All rights reserved.  
-[HNHUi](https://github.com/mstarke/HNHUi) Copyright 2012 HicknHack Software GmbH. All rights reserved.  
-[MiniKeePass](https://github.com/MiniKeePass/MiniKeePass) Copyright 2011 Jason Rush and John Flanagan. All rights reserved.  
-[KeePass Database Library](https://github.com/mpowrie/KeePassLib) Copyright 2010 Qiang Yu. All rights reserved.  
-[PXSourceList](https://github.com/Perspx/PXSourceList) Copyright 2011, Alex Rozanski. All rights reserved.  
-[KSPasswordField](https://github.com/karelia/SecurityInterface) Copyright 2012 Mike Abdullah, Karelia Software. All rights reserved.  
-[DDHotKey](https://github.com/davedelong/DDHotKey) Copyright [Dave DeLong](http://www.davedelong.com). All rights reserved.  
-[Sparkle](http://sparkle.andymatuschak.org) Copyright 2006 Andy Matuschak  
-[TransformerKit](https://github.com/mattt/TransformerKit) Licensed under MIT license. Copyright 2012 [Mattt Thompson](http://mattt.me/). All rights reserved  
-[MJGFoundation](https://github.com/mstarke/MJGFoundation) Licensed under BSD 2-Clause License. Copyright 2011 [Matt Galloway](http://www.galloway.me.uk/). All rights reserved.  
-[ShortcutRecorder](http://wafflesoftware.net/shortcut/) Copyright 2006—2013 all [Shortcut Recorder contributors](http://wafflesoftware.net/shortcut/contributors/)  
+[KeePassKit](https://github.com/MacPass/KeePassKit) Copyright 2012 HicknHack Software GmbH. All rights reserved.
+[HNHUi](https://github.com/mstarke/HNHUi) Copyright 2012 HicknHack Software GmbH. All rights reserved.
+[MiniKeePass](https://github.com/MiniKeePass/MiniKeePass) Copyright 2011 Jason Rush and John Flanagan. All rights reserved.
+[KeePass Database Library](https://github.com/mpowrie/KeePassLib) Copyright 2010 Qiang Yu. All rights reserved.
+[PXSourceList](https://github.com/Perspx/PXSourceList) Copyright 2011, Alex Rozanski. All rights reserved.
+[KSPasswordField](https://github.com/karelia/SecurityInterface) Copyright 2012 Mike Abdullah, Karelia Software. All rights reserved.
+[DDHotKey](https://github.com/davedelong/DDHotKey) Copyright [Dave DeLong](http://www.davedelong.com). All rights reserved.
+[Sparkle](http://sparkle.andymatuschak.org) Copyright 2006 Andy Matuschak
+[TransformerKit](https://github.com/mattt/TransformerKit) Licensed under MIT license. Copyright 2012 [Mattt Thompson](http://mattt.me/). All rights reserved
+[MJGFoundation](https://github.com/mstarke/MJGFoundation) Licensed under BSD 2-Clause License. Copyright 2011 [Matt Galloway](http://www.galloway.me.uk/). All rights reserved.
+[ShortcutRecorder](http://wafflesoftware.net/shortcut/) Copyright 2006—2013 all [Shortcut Recorder contributors](http://wafflesoftware.net/shortcut/contributors/)
 [NSBundle Codesignature Check](http://jedda.me/2012/03/verifying-plugin-bundles-using-code-signing/) Copyright 2014 [Jedda Wignall](http://jedda.me). All rights reserved.
 
 See submodules for additional Licenses


### PR DESCRIPTION
Found some references to the previous organization. Nice to have no redirects.