### PR TITLE
German localisation improved, one typo in US localisation corrected

### DIFF
--- a/MacPass/de.lproj/AutotypeCandidateSelectionView.strings
+++ b/MacPass/de.lproj/AutotypeCandidateSelectionView.strings
@@ -2,14 +2,14 @@
 "60p-7v-Nje.title" = "Abbrechen";
 
 /* Class = "NSTextFieldCell"; title = "There are multiple matches for the current window. Please select which match should be used."; ObjectID = "gcf-gb-ZsF"; */
-"gcf-gb-ZsF.title" = "Es gibt mehrere Treffer für den aktuellen Fenstertitel. Bitte wählen Sie den Eintrag aus der Liste aus, welcher verwendet werden soll.";
+"gcf-gb-ZsF.title" = "Es gibt mehrere Treffer für den aktuellen Fenstertitel. Bitte wählen Sie denjenigen Eintrag aus der Liste aus, der verwendet werden soll!";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PKW-gr-yqN"; */
-"PKW-gr-yqN.title" = "Text Cell";
+"PKW-gr-yqN.title" = "Text-Element";
 
 /* Class = "NSTextFieldCell"; title = "Content"; ObjectID = "TN3-3a-LaA"; */
 "TN3-3a-LaA.title" = "Inhalt";
 
 /* Class = "NSButtonCell"; title = "Perform Autotype"; ObjectID = "w7H-hx-CUF"; */
-"w7H-hx-CUF.title" = "Autotype ausführen.";
+"w7H-hx-CUF.title" = "Autotype ausführen";
 

--- a/MacPass/de.lproj/AutotypeDoctorReportViewController.strings
+++ b/MacPass/de.lproj/AutotypeDoctorReportViewController.strings
@@ -2,7 +2,7 @@
 "1Nx-Cg-TCn.title" = "Berechtigung anfordern …";
 
 /* Class = "NSTextFieldCell"; title = "MacPass will send key press events to the system when Autotype or Global Autotype is executed. Since macOS 10.14 Mojave this is only possible, if Accessibility permissions are granted to the application."; ObjectID = "6GI-KJ-Xue"; */
-"6GI-KJ-Xue.title" = "MacPass sendet Tastendrücke an das System, wenn Autotype oder Global Autotype ausgeführt wird. Seit macOS 10.14 Mojave ist dies nur noch möglich, wenn der Anwendung Berechtigung zur Bedienungshilfe erteilt wurden.";
+"6GI-KJ-Xue.title" = "MacPass sendet Tastendrücke an das System, wenn Autotype oder Global Autotype ausgeführt wird. Seit macOS 10.14 Mojave ist dies nur noch möglich, wenn der Anwendung die Berechtigung zur Bedienungshilfe erteilt wurden.";
 
 /* Class = "NSTextFieldCell"; title = "MacPass will read every window title when Global Autotype is executed to find a match. Since macOS 10.15 Catalina it is not possible to read any window title, if the user has not granted permissions to record the screen. If you are running macOS 10.15 or higher, MacPass will check if it can read every window title of currently visible windows. This test will not read the actual title. The titles aren't stored or processed in any way."; ObjectID = "7of-1z-Nfk"; */
 "7of-1z-Nfk.title" = "MacPass liest jeden Fenstertitel, wenn Global Autotype ausgeführt wird, um eine Übereinstimmung zu finden. Seit macOS 10.15 Catalina ist es nicht mehr möglich, einen Fenstertitel zu lesen, wenn der Benutzer keine Berechtigung zur Aufzeichnung des Bildschirms erteilt hat. Wenn Sie macOS 10.15 oder höher verwenden, wird MacPass prüfen, ob es jeden Fenstertitel der aktuell sichtbaren Fenster lesen kann. Dieser Test liest weder den aktuellen Titel, noch wird dieser gespeichert oder verarbeitet.";
@@ -17,8 +17,8 @@
 "aIL-8W-63g.title" = "Bedienungshilfen";
 
 /* Class = "NSButtonCell"; title = "Open Screen Recording Preferences…"; ObjectID = "lgB-Ys-L9R"; */
-"lgB-Ys-L9R.title" = "Bildschirmaufzeichnungseinstellungen öffnen …";
+"lgB-Ys-L9R.title" = "Bildschirm-Aufzeichnungs-Einstellungen öffnen …";
 
 /* Class = "NSTextFieldCell"; title = "To request Screen Recording permissions, MacPass will try to capture a 1 by 1 Pixel sized screenshot of the top left part of your screen. The data is not stored nor processed in any way."; ObjectID = "Mhg-rd-1hK"; */
-"Mhg-rd-1hK.title" = "Um die Berechtigung zum Aufzeichnen des Bildschirminhaltes anzufordern wird MacPass versuchen ein 1 mal 1 Pixel großes Bildschirmfoto vom linken oberen Rand des Bildschirms zu erstellen. Das Bild wird nicht gespeichert, gesendet oder anderweitig verarbeitet.";
+"Mhg-rd-1hK.title" = "Um die Berechtigung zum Aufzeichnen des Bildschirminhaltes anzufordern, wird MacPass versuchen, ein 1 mal 1 Pixel großes Bildschirmfoto vom linken oberen Rand des Bildschirms zu erstellen. Das Bild wird nicht gespeichert, gesendet oder anderweitig verarbeitet.";
 

--- a/MacPass/de.lproj/DatabaseSettingsWindow.strings
+++ b/MacPass/de.lproj/DatabaseSettingsWindow.strings
@@ -8,7 +8,7 @@
 "2ZA-Gc-JdZ.title" = "Wiederholungen";
 
 /* Class = "NSTextFieldCell"; title = "Enforce key change"; ObjectID = "5QH-N1-FHK"; */
-"5QH-N1-FHK.title" = "Erzwingen der Änderung des Schlüssels";
+"5QH-N1-FHK.title" = "Erzwinge Schlüsseländerung";
 
 /* Class = "NSTabViewItem"; label = "Argon2"; ObjectID = "6qB-sH-9FI"; */
 "6qB-sH-9FI.label" = "Argon 2";
@@ -38,7 +38,7 @@
 "536.title" = "Papierkorb aktivieren";
 
 /* Class = "NSTextFieldCell"; title = "Maximum items in history:"; ObjectID = "558"; */
-"558.title" = "Maximale Einträge:";
+"558.title" = "Maximal Anzahl Einträge in der Historie:";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "680"; */
 "680.title" = "OtherViews";
@@ -47,7 +47,7 @@
 "957.title" = "Abbrechen";
 
 /* Class = "NSTextFieldCell"; title = "Maximum history size:"; ObjectID = "1269"; */
-"1269.title" = "Maximale Größe:";
+"1269.title" = "Maximale Größe der Historie:";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1396"; */
 "1396.title" = "OtherViews";
@@ -68,7 +68,7 @@
 "1588.title" = "Vorgabegruppe:";
 
 /* Class = "NSTextFieldCell"; title = "Default Username:"; ObjectID = "1591"; */
-"1591.title" = "Vorgabebenutzername:";
+"1591.title" = "Default-Benutzername:";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1740"; */
 "1740.title" = "OtherViews";
@@ -77,7 +77,7 @@
 "bTk-YZ-x0G.title" = "Dateiformat:";
 
 /* Class = "NSButtonCell"; title = "Recommend key change"; ObjectID = "CtU-Eq-dgy"; */
-"CtU-Eq-dgy.title" = "Änderung des Schlüssels empfehlen";
+"CtU-Eq-dgy.title" = "Schlüsseländerung empfehlen";
 
 /* Class = "NSTabViewItem"; label = "Aes"; ObjectID = "ft1-pl-lpO"; */
 "ft1-pl-lpO.label" = "AES";
@@ -98,10 +98,10 @@
 "pA1-aL-KjT.title" = "Änderung des Schlüssels einmal nach dem Entsperren erzwingen";
 
 /* Class = "NSBox"; title = "Key derivation"; ObjectID = "pbl-Mb-r8V"; */
-"pbl-Mb-r8V.title" = "Schlüsselherleitung";
+"pbl-Mb-r8V.title" = "Schlüssel-Ableitung";
 
 /* Class = "NSButtonCell"; title = "Generate Parameters"; ObjectID = "PoI-Er-Y8P"; */
-"PoI-Er-Y8P.title" = "Parameter bestimmen";
+"PoI-Er-Y8P.title" = "Parameter erstellen";
 
 /* Class = "NSTextFieldCell"; title = "VersionInfo"; ObjectID = "Ush-4r-A1A"; */
 "Ush-4r-A1A.title" = "Versionsinformation";
@@ -110,8 +110,8 @@
 "uUQ-9s-M5E.title" = "Runden";
 
 /* Class = "NSTextFieldCell"; title = "Recommend key change"; ObjectID = "Xib-Fn-sqx"; */
-"Xib-Fn-sqx.title" = "Empfehlung zur Änderung des Schlüssels";
+"Xib-Fn-sqx.title" = "Schlüsseländerung empfehlen";
 
 /* Class = "NSButtonCell"; title = "Force key change"; ObjectID = "z6u-YT-7LE"; */
-"z6u-YT-7LE.title" = "Änderung des Schlüssels erzwingen";
+"z6u-YT-7LE.title" = "Erzwinge Schlüsseländerung";
 

--- a/MacPass/de.lproj/EntryInspectorView.strings
+++ b/MacPass/de.lproj/EntryInspectorView.strings
@@ -2,7 +2,7 @@
 "0ok-MC-QMP.title" = "Speichern";
 
 /* Class = "NSButtonCell"; title = "Enable Autotype"; ObjectID = "9Nx-mE-DK3"; */
-"9Nx-mE-DK3.title" = "Auto-Type aktivieren";
+"9Nx-mE-DK3.title" = "Autotype aktivieren";
 
 /* Class = "NSButtonCell"; title = "Generate"; ObjectID = "64"; */
 "64.title" = "Generieren";
@@ -14,7 +14,7 @@
 "66.title" = "URL";
 
 /* Class = "NSTextFieldCell"; title = "Username"; ObjectID = "69"; */
-"69.title" = "Benutzername";
+"69.title" = "Nutzername";
 
 /* Class = "NSTextFieldCell"; title = "Title"; ObjectID = "71"; */
 "71.title" = "Titel";
@@ -59,7 +59,7 @@
 "238.ibShadowedLabels[1]" = "Dateien";
 
 /* Class = "NSSegmentedCell"; 238.ibShadowedLabels[2] = "Autotype"; ObjectID = "238"; */
-"238.ibShadowedLabels[2]" = "Auto-Type";
+"238.ibShadowedLabels[2]" = "Autotype";
 
 /* Class = "NSMenuItem"; title = "Delete"; ObjectID = "bke-G2-oEf"; */
 "bke-G2-oEf.title" = "Löschen";
@@ -68,7 +68,7 @@
 "bkO-Bk-AuX.title" = "Fenstername";
 
 /* Class = "NSTextFieldCell"; title = "Autotype Sequence"; ObjectID = "bQ5-0E-h3O"; */
-"bQ5-0E-h3O.title" = "Auto-Type-Sequenz";
+"bQ5-0E-h3O.title" = "Autotype-Sequenz";
 
 /* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "dyA-lo-PGa"; */
 "dyA-lo-PGa.title" = "Table View Cell";
@@ -77,10 +77,10 @@
 "ep5-bQ-cfZ.title" = "Text Cell";
 
 /* Class = "NSTextFieldCell"; placeholderString = "Custom Window Sequence"; ObjectID = "fW9-9p-wwR"; */
-"fW9-9p-wwR.placeholderString" = "Benutzerdefinierte Fenstersequenz";
+"fW9-9p-wwR.placeholderString" = "Nutzerdefinierte Fenstersequenz";
 
 /* Class = "NSTabViewItem"; label = "Autotype"; ObjectID = "hK7-Dx-yjH"; */
-"hK7-Dx-yjH.label" = "Auto-Type";
+"hK7-Dx-yjH.label" = "Autotype";
 
 /* Class = "NSTextFieldCell"; title = "Window Associations"; ObjectID = "ned-1Q-FXA"; */
 "ned-1Q-FXA.title" = "Fenster-Zuordnungen";
@@ -89,10 +89,10 @@
 "NtM-y3-l4D.title" = "Quicklook";
 
 /* Class = "NSButtonCell"; title = "Obfuscate Autotype"; ObjectID = "oNq-kB-3eb"; */
-"oNq-kB-3eb.title" = "Auto-Type verschleiern";
+"oNq-kB-3eb.title" = "Autotype verschleiern";
 
 /* Class = "NSTextFieldCell"; placeholderString = "Custom Entry Sequence"; ObjectID = "R2X-Ex-c6q"; */
-"R2X-Ex-c6q.placeholderString" = "Benutzerdefinierte Sequenz";
+"R2X-Ex-c6q.placeholderString" = "Nutzerdefinierte Sequenz";
 
 /* Class = "NSTextFieldCell"; title = "Window Sequence"; ObjectID = "RQB-bR-MC0"; */
 "RQB-bR-MC0.title" = "Fenstersequenz";

--- a/MacPass/de.lproj/EntryInspectorView.strings
+++ b/MacPass/de.lproj/EntryInspectorView.strings
@@ -59,7 +59,7 @@
 "238.ibShadowedLabels[1]" = "Dateien";
 
 /* Class = "NSSegmentedCell"; 238.ibShadowedLabels[2] = "Autotype"; ObjectID = "238"; */
-"238.ibShadowedLabels[2]" = "Autotype";
+"238.ibShadowedLabels[2]" = "Auto-Type";
 
 /* Class = "NSMenuItem"; title = "Delete"; ObjectID = "bke-G2-oEf"; */
 "bke-G2-oEf.title" = "Löschen";
@@ -83,7 +83,7 @@
 "hK7-Dx-yjH.label" = "Auto-Type";
 
 /* Class = "NSTextFieldCell"; title = "Window Associations"; ObjectID = "ned-1Q-FXA"; */
-"ned-1Q-FXA.title" = "Fenster-Assoziationen";
+"ned-1Q-FXA.title" = "Fenster-Zuordnungen";
 
 /* Class = "NSMenuItem"; title = "Quicklook"; ObjectID = "NtM-y3-l4D"; */
 "NtM-y3-l4D.title" = "Quicklook";
@@ -104,5 +104,5 @@
 "vTq-N1-5oa.title" = "UUID";
 
 /* Class = "NSButtonCell"; title = "Show Plugin Data"; ObjectID = "X9y-K7-lix"; */
-"X9y-K7-lix.title" = "Plugindaten anzeigen";
+"X9y-K7-lix.title" = "Plugin-Daten anzeigen";
 

--- a/MacPass/de.lproj/GeneralPreferences.strings
+++ b/MacPass/de.lproj/GeneralPreferences.strings
@@ -29,7 +29,7 @@
 "465.title" = "Sicherheit";
 
 /* Class = "NSButtonCell"; title = "Reopen last Database after Launch"; ObjectID = "531"; */
-"531.title" = "Letzte Datenbank beim Start wieder öffnen";
+"531.title" = "Zuletzt verwendete Datenbank beim Start wieder öffnen";
 
 /* Class = "NSMenu"; title = "LockTimes"; ObjectID = "586"; */
 "586.title" = "Sperrzeiten";
@@ -59,7 +59,7 @@
 "ACh-7H-42N.title" = "Das Einschalten dieser Option beeinträchtigt die Sicherheit. Wird diese Option aktiviert, werden Pfadangaben von Datenbank und Schlüsseldatei in den persönlichen Einstellungen gespeichert. Zu Datenbanken ohne Passwort wird kein Schlüsseldatei-Pfad gespeichert.";
 
 /* Class = "NSButtonCell"; title = "Lock after log out"; ObjectID = "Dzn-9R-JjE"; */
-"Dzn-9R-JjE.title" = "Nach ausloggen sperren";
+"Dzn-9R-JjE.title" = "Nach Abmelden (logout) sperren";
 
 /* Class = "NSButtonCell"; title = "Prevent Universal Clipboard support"; ObjectID = "fNy-mS-phi"; */
 "fNy-mS-phi.title" = "Universelle Zwischenablage";

--- a/MacPass/de.lproj/GroupInspectorView.strings
+++ b/MacPass/de.lproj/GroupInspectorView.strings
@@ -1,5 +1,5 @@
 /* Class = "NSTextFieldCell"; title = "Autotype Sequence"; ObjectID = "6FG-UZ-Adh"; */
-"6FG-UZ-Adh.title" = "Auto-Type-Sequenz";
+"6FG-UZ-Adh.title" = "Autotype-Sequenz";
 
 /* Class = "NSTextFieldCell"; title = "Name"; ObjectID = "25"; */
 "25.title" = "Name";
@@ -17,7 +17,7 @@
 "265.title" = "Suche";
 
 /* Class = "NSTextFieldCell"; title = "Autotype"; ObjectID = "277"; */
-"277.title" = "Auto-Type";
+"277.title" = "Autotype";
 
 /* Class = "NSButtonCell"; title = "Show Plugin Data"; ObjectID = "qGr-oT-WjP"; */
 "qGr-oT-WjP.title" = "Plugin-Daten anzeigen";

--- a/MacPass/de.lproj/GroupInspectorView.strings
+++ b/MacPass/de.lproj/GroupInspectorView.strings
@@ -1,5 +1,5 @@
 /* Class = "NSTextFieldCell"; title = "Autotype Sequence"; ObjectID = "6FG-UZ-Adh"; */
-"6FG-UZ-Adh.title" = "Autotype-Sequenz";
+"6FG-UZ-Adh.title" = "Auto-Type-Sequenz";
 
 /* Class = "NSTextFieldCell"; title = "Name"; ObjectID = "25"; */
 "25.title" = "Name";
@@ -17,7 +17,7 @@
 "265.title" = "Suche";
 
 /* Class = "NSTextFieldCell"; title = "Autotype"; ObjectID = "277"; */
-"277.title" = "Autotype";
+"277.title" = "Auto-Type";
 
 /* Class = "NSButtonCell"; title = "Show Plugin Data"; ObjectID = "qGr-oT-WjP"; */
 "qGr-oT-WjP.title" = "Plugin-Daten anzeigen";

--- a/MacPass/de.lproj/IconSelection.strings
+++ b/MacPass/de.lproj/IconSelection.strings
@@ -2,7 +2,7 @@
 "1kM-cI-P1o.title" = "Abbrechen";
 
 /* Class = "NSButtonCell"; title = "Use Default Icon"; ObjectID = "102"; */
-"102.title" = "Standardicon verwenden";
+"102.title" = "Standard-Icon verwenden";
 
 /* Class = "NSButtonCell"; title = "Download Icon"; ObjectID = "iaf-XW-XUo"; */
 "iaf-XW-XUo.title" = "Icon herunterladen";

--- a/MacPass/de.lproj/InfoPlist.strings
+++ b/MacPass/de.lproj/InfoPlist.strings
@@ -2,25 +2,25 @@
 "CFBundleName" = "MacPass";
 
 /* (No Comment) */
-"KDB Database" = "KDB Datenbank";
+"KDB Database" = "KDB-Datenbank";
 
 /* (No Comment) */
-"KDBX Database" = "KDBX Datenbank";
+"KDBX Database" = "KDBX-Datenbank";
 
 /* (No Comment) */
-"MacPass Plugin" = "MacPass Plugin";
+"MacPass Plugin" = "MacPass-Plugin";
 
 /* Privacy - AppleEvents Sending Usage Description */
-"NSAppleEventsUsageDescription" = "MacPass erlaubt Plugins AppleEvents zu nutzen.";
+"NSAppleEventsUsageDescription" = "MacPass erlaubt Plugins, Apple Events zu nutzen.";
 
 /* Privacy - Desktop Folder Usage Description */
 "NSDesktopFolderUsageDescription" = "MacPass greift auf den Schreibtisch zu, um Datenbanken und Schlüsseldateien zu laden oder speichern.";
 
 /* Privacy - Documents Folder Usage Description */
-"NSDocumentsFolderUsageDescription" = "MacPass greift auf den Dokumenteordner zu, um Datenbanken und Schlüsseldateien zu laden oder speichern.";
+"NSDocumentsFolderUsageDescription" = "MacPass greift auf den Dokumente-Ordner zu, um Datenbanken und Schlüsseldateien zu laden oder speichern.";
 
 /* Privacy - Downloads Folder Usage Description */
-"NSDownloadsFolderUsageDescription" = "MacPass greift auf den Downloadordner zu, um Datenbanken und Schlüsseldateien zu laden oder speichern.";
+"NSDownloadsFolderUsageDescription" = "MacPass greift auf den Download-Ordner zu, um Datenbanken und Schlüsseldateien zu laden oder speichern.";
 
 /* (No Comment) */
 "NSHumanReadableCopyright" = "Copyright ©2012-2020 HicknHack Software GmbH. Alle Rechte vorbehalten.";

--- a/MacPass/de.lproj/IntegrationPreferences.strings
+++ b/MacPass/de.lproj/IntegrationPreferences.strings
@@ -1,5 +1,5 @@
 /* Class = "NSButtonCell"; title = "Enable global Autotype"; ObjectID = "1qb-Rd-jYu"; */
-"1qb-Rd-jYu.title" = "Globales Autotype aktivieren";
+"1qb-Rd-jYu.title" = "Globales Auto-Type aktivieren";
 
 /* Class = "NSTextFieldCell"; title = "Shortcut"; ObjectID = "6oN-CH-T0O"; */
 "6oN-CH-T0O.title" = "Tastatur-Kurzbefehl";
@@ -11,7 +11,7 @@
 "ERs-ct-Eyx.title" = "Quicklook-Vorschau aktivieren";
 
 /* Class = "NSTextFieldCell"; title = "Autotype might not work properly. Some issues where found that prevent Autotype or Global Autotype to work. Please run the Autotype Doctor to fix those issues."; ObjectID = "H37-ku-aTc"; */
-"H37-ku-aTc.title" = "Autotype steht nicht zur Verfügung, da MacPass den Computer nicht steuern darf. Um Autotype zu ermöglichen, fügen Sie MacPass in den Einstellungen zur Privatsphäre zu den Bedienungshilfen hinzu.";
+"H37-ku-aTc.title" = "Auto-Type steht nicht zur Verfügung, da MacPass den Computer nicht steuern darf. Um Auto-Type zu ermöglichen, fügen Sie MacPass in den Einstellungen zur Privatsphäre zu den Bedienungshilfen hinzu.";
 
 /* Class = "NSTextFieldCell"; title = "Shortcut is missing Key"; ObjectID = "Lxp-wI-yQy"; */
 "Lxp-wI-yQy.title" = "Der Kurzbefehl ist unvollständig";
@@ -26,7 +26,7 @@
 "QfO-yG-l3F.title" = "^ als ⌘ interpretieren";
 
 /* Class = "NSTextFieldCell"; title = "If enabled, every {CONTROL} command will be sent as ⌘. Only disable this if you are sure you need to."; ObjectID = "QRy-CY-ENC"; */
-"QRy-CY-ENC.title" = "Wenn aktiviert, werden {CONTROL} Befehle als ⌘ gesendet. Deaktivieren Sie diese Option nur, wenn Sie sich dessen sicher sind.";
+"QRy-CY-ENC.title" = "Wenn aktiviert, werden {CONTROL}-Befehle als ⌘ gesendet. Deaktivieren Sie diese Option nur, wenn Sie sich sicher sind.";
 
 /* Class = "NSButtonCell"; title = "Include Entry Tags for matches"; ObjectID = "rbu-G7-MT8"; */
 "rbu-G7-MT8.title" = "Tags beim Suchen von Einträgen berücksichtigen";
@@ -41,5 +41,5 @@
 "VVs-b5-cX9.title" = "Vorschau";
 
 /* Class = "NSTextFieldCell"; title = "If enabled attached files will be copied to a temporary location for preview and deleted after the preview is closed."; ObjectID = "WmI-IB-Aso"; */
-"WmI-IB-Aso.title" = "Die Daten werden zur Vorschau in einem temporären Ordern entschlüsselt und beim Beenden der Vorschau wieder gelöscht. Dieses Feature ist eine potenzielle Sicherheitslücke!";
+"WmI-IB-Aso.title" = "Die Daten werden zur Vorschau in einem temporären Ordern entschlüsselt und beim Beenden der Vorschau wieder gelöscht. Diese Funktionalität ist eine potenzielle Sicherheitslücke!";
 

--- a/MacPass/de.lproj/IntegrationPreferences.strings
+++ b/MacPass/de.lproj/IntegrationPreferences.strings
@@ -1,5 +1,5 @@
 /* Class = "NSButtonCell"; title = "Enable global Autotype"; ObjectID = "1qb-Rd-jYu"; */
-"1qb-Rd-jYu.title" = "Globales Auto-Type aktivieren";
+"1qb-Rd-jYu.title" = "Globales Autotype aktivieren";
 
 /* Class = "NSTextFieldCell"; title = "Shortcut"; ObjectID = "6oN-CH-T0O"; */
 "6oN-CH-T0O.title" = "Tastatur-Kurzbefehl";
@@ -11,7 +11,7 @@
 "ERs-ct-Eyx.title" = "Quicklook-Vorschau aktivieren";
 
 /* Class = "NSTextFieldCell"; title = "Autotype might not work properly. Some issues where found that prevent Autotype or Global Autotype to work. Please run the Autotype Doctor to fix those issues."; ObjectID = "H37-ku-aTc"; */
-"H37-ku-aTc.title" = "Auto-Type steht nicht zur Verfügung, da MacPass den Computer nicht steuern darf. Um Auto-Type zu ermöglichen, fügen Sie MacPass in den Einstellungen zur Privatsphäre zu den Bedienungshilfen hinzu.";
+"H37-ku-aTc.title" = "Autotype steht nicht zur Verfügung, da MacPass den Computer nicht steuern darf. Um Autotype zu ermöglichen, fügen Sie MacPass in den Einstellungen zur Privatsphäre zu den Bedienungshilfen hinzu.";
 
 /* Class = "NSTextFieldCell"; title = "Shortcut is missing Key"; ObjectID = "Lxp-wI-yQy"; */
 "Lxp-wI-yQy.title" = "Der Kurzbefehl ist unvollständig";

--- a/MacPass/de.lproj/Localizable.strings
+++ b/MacPass/de.lproj/Localizable.strings
@@ -108,7 +108,7 @@
 "AUTOTYPE_DOCTOR_RESULTS_WINDOW_TITLE" = "Autotype-Doktor";
 
 /* Inherit autotype settings menu item */
-"AUTOTYPE_INHERIT" = "Auto-Type-Einstellungen vererben";
+"AUTOTYPE_INHERIT" = "Autotype-Einstellungen vererben";
 
 /* Message displayed to the user to unlock the database to perform global autotype */
 "AUTOTYPE_MESSAGE_UNLOCK_DATABASE" = "Bitte entsperren Sie die Datenbank, um Global-Auto-Type nutzen zu können.";
@@ -120,7 +120,7 @@
 "AUTOTYPE_NOTIFICATION_MACPASS_IS_MISSING_PERMISSIONS" = "MacPass hat nicht alle notwendigen Berechtigungen, um Auto-Type ausführen zu können";
 
 /* Notification: Title for autotype feedback */
-"AUTOTYPE_NOTIFICATION_MATCH_TITLE" = "Auto-Type";
+"AUTOTYPE_NOTIFICATION_MATCH_TITLE" = "Autotype";
 
 /* Notification: Autotype failed, no documents are open */
 "AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_INFORMATIVE_TEXT" = "Bitte öffnen Sie eine Datei, um Global-Auto-Type zu nutzen!";
@@ -153,10 +153,10 @@
 "AUTOTYPE_STATUS_SCREEN_RECORDING_PERMISSIONS_OK" = "MacPass hat die Berechtigung, den Bildschirminhalt aufzuzeichnen";
 
 /* Notficication: Autotype timed out */
-"AUTOTYPE_TIMED_OUT" = "Auto-Type wegen zu langer Wartezeit abgebrochen";
+"AUTOTYPE_TIMED_OUT" = "Autotype wegen zu langer Wartezeit abgebrochen";
 
 /* Enable autotype menu item */
-"AUTOTYPE_YES" = "Auto-Type aktivieren";
+"AUTOTYPE_YES" = "Autotype aktivieren";
 
 /* Cancel */
 "CANCEL" = "Abbrechen";
@@ -208,7 +208,7 @@
 "COPIED_URL_REFERENCE" = "URL-Referenz kopiert!";
 
 /* Username was copied to the pasteboard */
-"COPIED_USERNAME" = "Benutzername kopiert!";
+"COPIED_USERNAME" = "Nutzername kopiert!";
 
 /* Context menu that copies reference to username */
 "COPIED_USERNAME_REFERENCE" = "Nutzernamereferenz kopiert!";
@@ -564,7 +564,7 @@
 "PASSWORD_INPUT_REPEAT_PASSWORD" = "Passwort wiederholen";
 
 /* Menu item to perform autotype with the selected entry */
-"PERFORM_AUTOTYPE_FOR_ENTRY" = "Auto-Type ausführen";
+"PERFORM_AUTOTYPE_FOR_ENTRY" = "Autotype ausführen";
 
 /* Info about how many character has to pick in pickchar dialog */
 "PICKCHAR_INFO_MESSAGE_PICK_CHARACTERS_%ld" = "Bitte %ld Zeichen wählen";
@@ -636,7 +636,7 @@
 "PREVIEW" = "Vorschau";
 
 /* Recent searches menu item */
-"RECENT_SEARCHES" = "Letzte Suchanfragen";
+"RECENT_SEARCHES" = "Neueste Suchanfragen";
 
 /* Informative text for the recommend password change alert */
 "RECOMMEND_PASSWORD_CHANGE_ALERT_DESCRIPTION" = "Sie sollten Passwort oder Schlüssel ändern.";
@@ -697,7 +697,7 @@
 "SELECT_DEFAULT_BROWSER_OPEN_PANEL_SELECT_BUTTON" = "Auswählen";
 
 /* Message for the dialog to open a file for merge */
-"SELECT_FILE_TO_MERGE" = "Datei für Synchronisation auswählen";
+"SELECT_FILE_TO_MERGE" = "Datei fürs Zusammenführen auswählen";
 
 /* Menu displayed as popup selection for search options if no filter is selected */
 "SELECT_FILTER_WITH_DOTS" = "Auswählen …";
@@ -706,7 +706,7 @@
 "SET_AS_DEFAULT_FILE_CHANGE_STRATEGY" = "Die gewählte Strategie immer verwenden. Sie können die Strategie jederzeit in den Einstellungen anpassen.";
 
 /* Action button in Notification to show the Autotype Doctor */
-"SHOW_AUTOTYPE_DOCTOR" = "Auto-Type-Doktor anzeigen";
+"SHOW_AUTOTYPE_DOCTOR" = "Autotype-Doktor anzeigen";
 
 /* Menu item to show the entries group in the outline view */
 "SHOW_GROUP_IN_OUTLINE" = "Gruppe in Übersicht anzeigen";
@@ -725,7 +725,7 @@
 "TOMORROW" = "Morgen";
 
 /* Toolbar item to perform autotype */
-"TOOLBAR_PERFORM_AUTOTYPE_FOR_ENTRY" = "Auto-Type";
+"TOOLBAR_PERFORM_AUTOTYPE_FOR_ENTRY" = "Autotype";
 
 /* Touchbar button label for choosing the keyfile */
 "TOUCHBAR_CHOOSE_KEYFILE" = "Schlüsseldatei wählen";
@@ -752,7 +752,7 @@
 "TOUCHBAR_NEW_GROUP" = "Neue Gruppe";
 
 /* Touchbar button label for performing autotype */
-"TOUCHBAR_PERFORM_AUTOTYPE" = "Auto-Type ausführen";
+"TOUCHBAR_PERFORM_AUTOTYPE" = "Autotype ausführen";
 
 /* Touchbar button label for searching the database */
 "TOUCHBAR_SEARCH" = "Datenbank durchsuchen";

--- a/MacPass/de.lproj/Localizable.strings
+++ b/MacPass/de.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "AUTOTYPE_NOTIFICATION_MATCH_TITLE" = "Autotype";
 
 /* Notification: Autotype failed, no documents are open */
-"AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_INFORMATIVE_TEXT" = "Bitte öffnen Sie eine Datei, um Global-Auto-Type zu nutzen!";
+"AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_INFORMATIVE_TEXT" = "Bitte öffnen Sie eine Datei, um Global-Autotype zu nutzen!";
 
 /* Notification: Title for autotype feedback */
 "AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_TITLE" = "Keine Datenbank geöffnet.";

--- a/MacPass/de.lproj/Localizable.strings
+++ b/MacPass/de.lproj/Localizable.strings
@@ -20,7 +20,7 @@
 "90_DAYS" = "in 90 Tagen";
 
 /* Button label to abort a merge on a file with changed master key! */
-"ABORT_MERGE_KEEP_MINE" = "Synchronisation abbrechen. Meine Version behalten.";
+"ABORT_MERGE_KEEP_MINE" = "Zusammmenführen abbrechen. Meine Version behalten.";
 
 /* Toolbar item with action menu */
 "ACTION" = "Aktion";
@@ -71,7 +71,7 @@
 "ALERT_MERGE_CANCEL" = "Abbrechen";
 
 /* Button in dialog to merge KDB changes into file! */
-"ALERT_MERGE_CONTINUE" = "Daten synchronisieren!";
+"ALERT_MERGE_CONTINUE" = "Daten zusammenführen!";
 
 /* Informative text displayed when merging KDB files */
 "ALERT_MERGE_KDB_FILE_INFO_TEXT" = "KDB-Datenbanken enthalten nicht alle notwendigen Informationen für eine eindeutige Synchronisation. Einzelne Einträgen werden korrekt synchronisiert. Gruppen werden jedoch nur durch den Namen zugeordnet werden, was zu unerwarteten Ergebnissen führen kann, z.B. können lokal verschobene Einträge wieder in alte Gruppen geschoben werden, unbenannte Gruppen können leer werden und die Einträge unter einer Gruppe mit dem vorherigen Namen wieder auftauchen. Weiterhin können gelöschte Einträge wieder auftauchen, da keine Informationen darüber gespeichert wird. Soll mit der Synchronisation fortgefahren werden?";

--- a/MacPass/de.lproj/Localizable.strings
+++ b/MacPass/de.lproj/Localizable.strings
@@ -111,13 +111,13 @@
 "AUTOTYPE_INHERIT" = "Autotype-Einstellungen vererben";
 
 /* Message displayed to the user to unlock the database to perform global autotype */
-"AUTOTYPE_MESSAGE_UNLOCK_DATABASE" = "Bitte entsperren Sie die Datenbank, um Global-Auto-Type nutzen zu können.";
+"AUTOTYPE_MESSAGE_UNLOCK_DATABASE" = "Bitte entsperren Sie die Datenbank, um Global-Autotype nutzen zu können.";
 
 /* Disable autotype menu item */
 "AUTOTYPE_NO" = "Autotype deaktivieren";
 
 /* Notification: Autotype failed, MacPass has not enough permissions to perform autotype */
-"AUTOTYPE_NOTIFICATION_MACPASS_IS_MISSING_PERMISSIONS" = "MacPass hat nicht alle notwendigen Berechtigungen, um Auto-Type ausführen zu können";
+"AUTOTYPE_NOTIFICATION_MACPASS_IS_MISSING_PERMISSIONS" = "MacPass hat nicht alle notwendigen Berechtigungen, um Autotype ausführen zu können";
 
 /* Notification: Title for autotype feedback */
 "AUTOTYPE_NOTIFICATION_MATCH_TITLE" = "Autotype";
@@ -178,7 +178,7 @@
 "CHOOSE_FILE_BUTTON_TITLE" = "Öffnen";
 
 /* Clear Autotype Button */
-"CLEAR_AUTOTYPE" = "Auto-Type löschen";
+"CLEAR_AUTOTYPE" = "Autotype löschen";
 
 /* Menu to clear recent searches */
 "CLEAR_RECENT_SEARCHES" = "Neueste Suchanfragen entfernen";

--- a/MacPass/de.lproj/Localizable.strings
+++ b/MacPass/de.lproj/Localizable.strings
@@ -20,34 +20,34 @@
 "90_DAYS" = "in 90 Tagen";
 
 /* Button label to abort a merge on a file with changed master key! */
-"ABORT_MERGE_KEEP_MINE" = "Synchronisation abbrechen. Meine Änderungen behalten.";
+"ABORT_MERGE_KEEP_MINE" = "Synchronisation abbrechen. Meine Version behalten.";
 
 /* Toolbar item with action menu */
 "ACTION" = "Aktion";
 
 /* Menu item title for adding an hmacotp config attribute */
-"ADD_CUSTOM_ATTRIBUTE_HMACOTP_CONFIG" = "HMACOTP Konfiguration hinzufügen";
+"ADD_CUSTOM_ATTRIBUTE_HMACOTP_CONFIG" = "HMACOTP-Konfiguration hinzufügen";
 
 /* Menu item title for adding an hmacotp seed attribute */
-"ADD_CUSTOM_ATTRIBUTE_HMACOTP_SEED" = "HMACOTP Startwert hinzufügen";
+"ADD_CUSTOM_ATTRIBUTE_HMACOTP_SEED" = "HMACOTP-Startwert hinzufügen";
 
 /* Menu displayed for adding special custom keys */
-"ADD_CUSTOM_FIELD_CONTEXT_MENU" = "Feld hinzufügen Menü";
+"ADD_CUSTOM_FIELD_CONTEXT_MENU" = "Menü für nutzerdefiniertes Feld hinzufügen";
 
 /* Action to add an entry via template */
-"ADD_TREMPLATE_ENTRY" = "Vorgabeeintrag erstellen";
+"ADD_TREMPLATE_ENTRY" = "Vorlage-Eintrag erstellen";
 
 /* Allow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Aktualisiere Daten online.";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_ALLOW_DOWNLOAD" = "Definitionen online aktualisieren.";
 
 /* Informative text displayed on the alert that shows up when MacPass asks for permssion to download the plugin repository JSON file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT" = "Das Verzeichnis ist auf https://macpassapp.org hinterlegt. MacPass lädt die Definitionen herunter, um sicher zu stellen, dass alle Daten auf dem neusten Stand sind.";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_INFORMATIVE_TEXT" = "Das Verzeichnis ist auf https://macpassapp.org hinterlegt. MacPass lädt die Definitionen herunter, um sicherzustellen, dass alle Daten auf dem neuesten Stand sind.";
 
 /* Message displayed on the alert that asks for permission to download the plugin repository JSON file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass möchte das Pluginverzeichnis aktualisieren.";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass möchte das Plugin-Verzeichnis aktualisieren.";
 
 /* Disallow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Keine Daten herunterladen.";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Definitionen nicht aktualisieren.";
 
 /* Button in dialog to leave plugin ds disabled and continiue! */
 "ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_BUTTON_OK" = "OK";
@@ -56,13 +56,13 @@
 "ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_BUTTON_OPEN_PREFERENCES" = "Plugin-Einstellungen öffnen …";
 
 /* Informative text of the alert displayed when plugins where disabled due to incompatibilty */
-"ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_INFORMATIVE_TEXT" = "Es wurden Plugins deaktiviert, da sie nicht kompatibel mit dieser Version von MacPass sind. Bitte öffnen Sie die Plugin-Einstellungen für mehr Informationen.";
+"ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_INFORMATIVE_TEXT" = "Es wurden Plugins deaktiviert, da sie nicht kompatibel mit dieser Version von MacPass sind. Bitte öffnen Sie die Plugin-Einstellungen für mehr Informationen!";
 
 /* Message text of the alert displayed when plugins where disabled due to incompatibilty */
 "ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_MESSAGE" = "Es wurden inkompatible Plugins gefunden.";
 
 /* Alert informative text when plugins or their settings change and require a restart */
-"ALERT_INFORMATIVE_TEXT_PLUGINS_CHANGED_SUGGEST_RESTART" = "Änderungen zu den globalen Einstellungen von Plugins treten erst nach einem Neustart in Kraft. Soll MacPass jetzt neu gestartet werden?";
+"ALERT_INFORMATIVE_TEXT_PLUGINS_CHANGED_SUGGEST_RESTART" = "Änderungen zu den globalen Einstellungen von Plugins werden erst nach einem Neustart wirksam. Soll MacPass jetzt neu gestartet werden?";
 
 /* Alert informative text to ask the user if he really want to uninstall the plugin */
 "ALERT_INFORMATIVE_TEXT_REALLY_UNINSTALL_PLUGIN" = "Das Plugin wird in den Papierkorb verschoben";
@@ -71,16 +71,16 @@
 "ALERT_MERGE_CANCEL" = "Abbrechen";
 
 /* Button in dialog to merge KDB changes into file! */
-"ALERT_MERGE_CONTINUE" = "Daten synchronisieren.";
+"ALERT_MERGE_CONTINUE" = "Daten synchronisieren!";
 
 /* Informative text displayed when merging KDB files */
-"ALERT_MERGE_KDB_FILE_INFO_TEXT" = "KDB Datenbanken enthalten nicht alle notwendigen Informationen für eine eindeutige Synchronisation. Einzelne Einträgen werden korrekt synchronisiert. Gruppen werden jedoch nur durch den Namens zugeordnet werden, was zu unerwarteten Ergebnissen führen kann. Etwa können lokal bewegte Einträge wieder in alte Gruppen geschoben werden, unbenannte Gruppen können leer werden und die Einträge unter einer Gruppe mit dem vorherigen Namen wieder auftauchen. Weiterhin können gelöschte Einträge wieder auftauchen, da keine Informationen über diese gespeichert wird. Soll mit der Synchronisation fortgefahren werden?";
+"ALERT_MERGE_KDB_FILE_INFO_TEXT" = "KDB-Datenbanken enthalten nicht alle notwendigen Informationen für eine eindeutige Synchronisation. Einzelne Einträgen werden korrekt synchronisiert. Gruppen werden jedoch nur durch den Namen zugeordnet werden, was zu unerwarteten Ergebnissen führen kann, z.B. können lokal verschobene Einträge wieder in alte Gruppen geschoben werden, unbenannte Gruppen können leer werden und die Einträge unter einer Gruppe mit dem vorherigen Namen wieder auftauchen. Weiterhin können gelöschte Einträge wieder auftauchen, da keine Informationen darüber gespeichert wird. Soll mit der Synchronisation fortgefahren werden?";
 
 /* Alert message warning user about KDB file merge */
-"ALERT_MERGE_KDB_FILE_MESSAGE" = "Es werden KDB Datenbanken synchronisiert!";
+"ALERT_MERGE_KDB_FILE_MESSAGE" = "Es werden KDB-Datenbanken synchronisiert!";
 
 /* Alert message text when plugins or their settings change and require a restart */
-"ALERT_MESSAGE_PLUGINS_CHANGED_SUGGEST_RESTART" = "Die globalen Plugineinstellungen haben sich geändert.";
+"ALERT_MESSAGE_PLUGINS_CHANGED_SUGGEST_RESTART" = "Die globalen Plugin-Einstellungen haben sich geändert.";
 
 /* Alert message text to ask the user if he really want to uninstall the plugin. Include %@ placeholder for plugin name */
 "ALERT_MESSAGE_TEXT_REALLY_UNINSTALL_PLUGIN_%@" = "Möchten Sie das Plugin %@ wirklich deinstallieren?";
@@ -89,7 +89,7 @@
 "ALERT_UPDATES_DISABLED_INFORMATIVE_TEXT_%@!" = "Aktualisierungen von %@ sind für diese Version deaktivert!";
 
 /* Message text for disabled updates alert! */
-"ALERT_UPDATES_DISABLED_MESSAGE_TEXT" = "Updates sind dekativiert.";
+"ALERT_UPDATES_DISABLED_MESSAGE_TEXT" = "Aktualisierungen sind deaktiviert.";
 
 /* Attachments column title (shows counts)
    Menu item to toggle display of attachment count column in entry table */
@@ -102,31 +102,31 @@
 "AUTOCREATE_TRASH_FOLDER" = "Automatisch erstellen";
 
 /* Message text in the autotype selection window. Placeholder is %1 - windowTitle */
-"AUTOTYPE_CANDIDATE_SELECTION_WINDOW_MESSAGE_%@" = "Es gibt mehrere Treffer für den aktuellen Fenstertitel: %@. Bitte wählen Sie den Eintrag aus der Liste aus, welcher verwendet werden soll.";
+"AUTOTYPE_CANDIDATE_SELECTION_WINDOW_MESSAGE_%@" = "Es gibt mehrere Treffer für den aktuellen Fenstertitel: %@. Bitte wählen Sie denjenigen Eintrag aus der Liste aus, der verwendet werden soll.";
 
 /* Window title for the stand-alone password creator window */
-"AUTOTYPE_DOCTOR_RESULTS_WINDOW_TITLE" = "Autotype Doktor";
+"AUTOTYPE_DOCTOR_RESULTS_WINDOW_TITLE" = "Autotype-Doktor";
 
 /* Inherit autotype settings menu item */
-"AUTOTYPE_INHERIT" = "Autotype Einstellungen vererben";
+"AUTOTYPE_INHERIT" = "Auto-Type-Einstellungen vererben";
 
 /* Message displayed to the user to unlock the database to perform global autotype */
-"AUTOTYPE_MESSAGE_UNLOCK_DATABASE" = "Bitte entsperren Sie die Datenbank um Global-Autotype nutzen zu können.";
+"AUTOTYPE_MESSAGE_UNLOCK_DATABASE" = "Bitte entsperren Sie die Datenbank, um Global-Auto-Type nutzen zu können.";
 
 /* Disable autotype menu item */
 "AUTOTYPE_NO" = "Autotype deaktivieren";
 
 /* Notification: Autotype failed, MacPass has not enough permissions to perform autotype */
-"AUTOTYPE_NOTIFICATION_MACPASS_IS_MISSING_PERMISSIONS" = "MacPass hat nicht alle notwendigen Berechtigungen um Autotype ausführen zu können";
+"AUTOTYPE_NOTIFICATION_MACPASS_IS_MISSING_PERMISSIONS" = "MacPass hat nicht alle notwendigen Berechtigungen, um Auto-Type ausführen zu können";
 
 /* Notification: Title for autotype feedback */
-"AUTOTYPE_NOTIFICATION_MATCH_TITLE" = "Autotype";
+"AUTOTYPE_NOTIFICATION_MATCH_TITLE" = "Auto-Type";
 
 /* Notification: Autotype failed, no documents are open */
-"AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_INFORMATIVE_TEXT" = "Bitte öffnen Sie eine Datei, um Global-Autotype zu nutzen!";
+"AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_INFORMATIVE_TEXT" = "Bitte öffnen Sie eine Datei, um Global-Auto-Type zu nutzen!";
 
 /* Notification: Title for autotype feedback */
-"AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_TITLE" = "Keine Datenbank offen.";
+"AUTOTYPE_NOTIFICATION_NO_DOCUMENTS_TITLE" = "Keine Datenbank geöffnet.";
 
 /* Noticiation: Autotype failed to find a match for %@ (string placeholder) */
 "AUTOTYPE_NOTIFICATION_NO_MATCH_FOR_%@" = "Kein Treffer für %@!";
@@ -141,22 +141,22 @@
 "AUTOTYPE_NOTIFICATION_TIMED_OUT_TITLE" = "Autotype abgebrochen.";
 
 /* Status label when no issue were found in accessibilty */
-"AUTOTYPE_STATUS_ACCESSIBILTY_PERMISSIONS_OK" = "MacPass hat die Berechtigung den Computer zu steuern (Eingabehilfe)";
+"AUTOTYPE_STATUS_ACCESSIBILTY_PERMISSIONS_OK" = "MacPass hat die Berechtigung, den Rechner zu steuern (Eingabehilfe)";
 
 /* Status MacPass has no accessibilty permissions */
-"AUTOTYPE_STATUS_NO_ACCESSIBILTY_PERMISSIONS" = "MacPass hat keine Berechtigung den Computer zu steuern (Eingabehilfe)";
+"AUTOTYPE_STATUS_NO_ACCESSIBILTY_PERMISSIONS" = "MacPass hat keine Berechtigung, den Rechner zu steuern (Eingabehilfe)";
 
 /* Status MacPass has no screen recording permissions */
-"AUTOTYPE_STATUS_NO_SCREEN_RECORDING_PERMISSIONS" = "MacPass hat keine Berechtigung den Bildschirminhalt aufzuzeichnen";
+"AUTOTYPE_STATUS_NO_SCREEN_RECORDING_PERMISSIONS" = "MacPass hat keine Berechtigung, den Bildschirminhalt aufzuzeichnen";
 
 /* Status label when no issue were found in screen recording permissions */
-"AUTOTYPE_STATUS_SCREEN_RECORDING_PERMISSIONS_OK" = "MacPass hat die Berechtigung den Bildschirminhalt aufzuzeichnen";
+"AUTOTYPE_STATUS_SCREEN_RECORDING_PERMISSIONS_OK" = "MacPass hat die Berechtigung, den Bildschirminhalt aufzuzeichnen";
 
 /* Notficication: Autotype timed out */
-"AUTOTYPE_TIMED_OUT" = "Autotype wegen zu langer Wartezeit abgebrochen";
+"AUTOTYPE_TIMED_OUT" = "Auto-Type wegen zu langer Wartezeit abgebrochen";
 
 /* Enable autotype menu item */
-"AUTOTYPE_YES" = "Autotype aktivieren";
+"AUTOTYPE_YES" = "Auto-Type aktivieren";
 
 /* Cancel */
 "CANCEL" = "Abbrechen";
@@ -165,7 +165,7 @@
 "CHANGE_DATABASE_NAME" = "Name der Datenbank ändern";
 
 /* Button to postpone the password change */
-"CHANGE_LATER" = "Später Ändern";
+"CHANGE_LATER" = "Später ändern";
 
 /* Button to show the password change dialog
    Single button to show the password change dialog */
@@ -178,10 +178,10 @@
 "CHOOSE_FILE_BUTTON_TITLE" = "Öffnen";
 
 /* Clear Autotype Button */
-"CLEAR_AUTOTYPE" = "Autotype Löschen";
+"CLEAR_AUTOTYPE" = "Auto-Type löschen";
 
 /* Menu to clear recent searches */
-"CLEAR_RECENT_SEARCHES" = "Letzte Suchanfragen entfernen";
+"CLEAR_RECENT_SEARCHES" = "Neueste Suchanfragen entfernen";
 
 /* String displayed at dock badge when clipboard is about to be cleared */
 "CLEARING_PASTEBOARD" = "…";
@@ -217,13 +217,13 @@
 "COPY_AS_REFERENCE" = "Kopiere Referenz auf …";
 
 /* Context menu sub-menu to copy attributes as reference */
-"COPY_AS_REFERENCE_MENU" = "Kopiere Referenz Menü";
+"COPY_AS_REFERENCE_MENU" = "Kopiere-Referenz-Menü";
 
 /* Submenu to Copy custom fields */
-"COPY_CUSTOM_FIELDS" = "Feld kopieren";
+"COPY_CUSTOM_FIELDS" = "Nutzerdefinierte Felder kopieren";
 
 /* Context menu sub-menu to copy custom fields to clipboard */
-"COPY_CUSTOM_FIELDS_MENU" = "Feld kopieren …";
+"COPY_CUSTOM_FIELDS_MENU" = "Nutzerdefiniertes Feld kopieren …";
 
 /* Action name when an entry was moved
    Action title for copying an entry via drag and drop */
@@ -256,7 +256,7 @@
 
 /* Menu item to copy the username of an entry
    Toolbar item copy username */
-"COPY_USERNAME" = "Benutzername kopieren";
+"COPY_USERNAME" = "Nutzername kopieren";
 
 /* Context menu that copies reference to username */
 "COPY_USERNAME_REFERENCE" = "Nutzername";
@@ -265,7 +265,7 @@
 "CUSTOM_ATTRIBUTE" = "Spezielle Eigenschaften";
 
 /* Title for menu for custom search filters */
-"CUSTOM_SEARCH_FILTER_MENU" = "Spezielle Suchefilter …";
+"CUSTOM_SEARCH_FILTER_MENU" = "Spezielle Suchfilter …";
 
 /* Default display name for KDB databases */
 "DATABASE" = "Datenbank";
@@ -341,7 +341,7 @@
 "EMPTY_TRASH" = "Papierkorb leeren";
 
 /* Informative text for the enforce password change alert */
-"ENFORCE_PASSWORD_CHANGE_ALERT_DESCRIPTION" = "Das Speichern der Datenbank ist erst wieder möglich, wenn das Passwort und/oder der Schlüssel geändert wurden.";
+"ENFORCE_PASSWORD_CHANGE_ALERT_DESCRIPTION" = "Das Speichern der Datenbank ist erst wieder möglich, wenn Passwort oder Schlüssel geändert wurden.";
 
 /* Message text for the enforce password change alert */
 "ENFORCE_PASSWORD_CHANGE_ALERT_TITLE" = "Das Passwort der Datenbank ist abgelaufen!";
@@ -362,16 +362,16 @@
 "ERROR_INVALID_PLUGIN" = "Kein MacPass-Plugin";
 
 /* Error description for missing accessibility permissions */
-"ERROR_NO_ACCESSIBILITY_PERMISSIONS" = "MacPass hat keine Berechtigung den Bildschirminhalt aufzuzeichnen.";
+"ERROR_NO_ACCESSIBILITY_PERMISSIONS" = "MacPass hat keine Berechtigung, den Bildschirminhalt aufzuzeichnen.";
 
 /* Error description for missing screen recording permissions */
-"ERROR_NO_PERMISSION_TO_RECORD_SCREEN" = "MacPass hat keine Berechtigungen den Bildschirminhalt aufzuzeichnen";
+"ERROR_NO_PERMISSION_TO_RECORD_SCREEN" = "MacPass hat keine Berechtigungen, den Bildschirminhalt aufzuzeichnen";
 
 /* Passwords do not match */
 "ERROR_PASSWORD_MISSMATCH" = "Passwörter stimmen nicht überein";
 
 /* Passwords do not match, keyfile is invalid */
-"ERROR_PASSWORD_MISSMATCH_INVALID_KEYFILE" = "Passwörter stimmen nicht überein oder die Schlüsseldatei ist ungültig!";
+"ERROR_PASSWORD_MISSMATCH_INVALID_KEYFILE" = "Passwörter stimmen nicht überein, oder die Schlüsseldatei ist ungültig!";
 
 /* Recommend/Enforce key change intervall format */
 "EVERY_%ld_DAYS" = "Alle %ld Tage";
@@ -393,7 +393,7 @@
 "FILE_CHANGE_STRATEGY_MERGE" = "Inhalte zusammenführen";
 
 /* External file change strategy option: Use the changed file and discard local changes */
-"FILE_CHANGE_STRATEGY_USE_OTHER" = "Lade die andere Version und verwerfe meine Änderungen";
+"FILE_CHANGE_STRATEGY_USE_OTHER" = "Lade die andere Version und verwirf meine Änderungen";
 
 /* Informative text displayed when the file was change from another application */
 "FILE_CHANGED_BY_OTHERS_INFO_TEXT" = "Die geöffnete Datei wurde von einem anderen Programm verändert! Der Inhalt stimmt nicht mehr mit dem geladenen Inhalt überein.";
@@ -430,16 +430,16 @@
 "KDBX_ONLY_FEATURE" = "Funktion nur in KDBX-Datenbank verfügbar";
 
 /* Button in dialog to ignore the changes to an open file! */
-"KEEP_MINE_DISCARD_OTHER" = "Behalte meine, verwerfe andere!";
+"KEEP_MINE_DISCARD_OTHER" = "Behalte meine, verwirf andere!";
 
 /* Button in dialog to reopen the file! */
-"KEEP_OTHER_DISCARD_MINE" = "Behalte andere, verwerfe meine!";
+"KEEP_OTHER_DISCARD_MINE" = "Behalte andere, verwirf meine!";
 
 /* Do not install the plugin */
-"KEEP_PLUGIN" = "Plugin Behalten";
+"KEEP_PLUGIN" = "Plugin behalten";
 
 /* Do not restart MacPass */
-"KEEP_RUNNING" = "Nicht Neustarten";
+"KEEP_RUNNING" = "Nicht neustarten";
 
 /* last week */
 "LAST_WEEK" = "Letze Woche";
@@ -461,7 +461,7 @@
 "MODIFIED" = "Verändert";
 
 /* Action name when an entry was moved */
-"MOVE_ENTRY" = "Eintrag bewegen";
+"MOVE_ENTRY" = "Eintrag verschieben";
 
 /* Menu displayed as popup selection for search options when multiple items are selected */
 "MULTIPLE_FILTERS_ACTIVE_WITH_DOTS" = "Mehrere …";
@@ -543,7 +543,7 @@
 "PASSWORD" = "Passwort";
 
 /* Window title for the stand-alone password creator window */
-"PASSWORD_CREATOR_WINDOW_TITLE" = "Passwortgenerator";
+"PASSWORD_CREATOR_WINDOW_TITLE" = "Passwort-Generator";
 
 /* Button to reset the password defaults for a single entry */
 "PASSWORD_GENERATOR_RESET_ENTRY_DEFAULTS" = "Zurücksetzen";
@@ -606,7 +606,7 @@
 "PLUGIN_ERROR_DISABLED_PLUGIN" = "Das Plugin ist vom Nutzer deaktiviert worden.";
 
 /* Plugin is not with this version of MacPass */
-"PLUGIN_ERROR_HOST_VERSION_NOT_SUPPORTED" = "Das Plugin ist nicht mit diese Version von MacPass kompatibel.";
+"PLUGIN_ERROR_HOST_VERSION_NOT_SUPPORTED" = "Das Plugin ist nicht mit dieser Version von MacPass kompatibel.";
 
 /* The plugin could not be initalized */
 "PLUGIN_ERROR_INTILIZATION_FAILED" = "Das Plugin konnten nicht korrekt initialisiert werden";
@@ -639,7 +639,7 @@
 "RECENT_SEARCHES" = "Letzte Suchanfragen";
 
 /* Informative text for the recommend password change alert */
-"RECOMMEND_PASSWORD_CHANGE_ALERT_DESCRIPTION" = "Sie sollten das Passwort und/oder den Schlüssel ändern.";
+"RECOMMEND_PASSWORD_CHANGE_ALERT_DESCRIPTION" = "Sie sollten Passwort oder Schlüssel ändern.";
 
 /* Message text for the recommend password change alert */
 "RECOMMEND_PASSWORD_CHANGE_ALERT_TITLE" = "Bitte ändern sie das Passwort der Datenbank!";
@@ -706,7 +706,7 @@
 "SET_AS_DEFAULT_FILE_CHANGE_STRATEGY" = "Die gewählte Strategie immer verwenden. Sie können die Strategie jederzeit in den Einstellungen anpassen.";
 
 /* Action button in Notification to show the Autotype Doctor */
-"SHOW_AUTOTYPE_DOCTOR" = "Autotype Doktor anzeigen";
+"SHOW_AUTOTYPE_DOCTOR" = "Auto-Type-Doktor anzeigen";
 
 /* Menu item to show the entries group in the outline view */
 "SHOW_GROUP_IN_OUTLINE" = "Gruppe in Übersicht anzeigen";
@@ -725,7 +725,7 @@
 "TOMORROW" = "Morgen";
 
 /* Toolbar item to perform autotype */
-"TOOLBAR_PERFORM_AUTOTYPE_FOR_ENTRY" = "Autotype";
+"TOOLBAR_PERFORM_AUTOTYPE_FOR_ENTRY" = "Auto-Type";
 
 /* Touchbar button label for choosing the keyfile */
 "TOUCHBAR_CHOOSE_KEYFILE" = "Schlüsseldatei wählen";
@@ -752,7 +752,7 @@
 "TOUCHBAR_NEW_GROUP" = "Neue Gruppe";
 
 /* Touchbar button label for performing autotype */
-"TOUCHBAR_PERFORM_AUTOTYPE" = "Autotype ausführen";
+"TOUCHBAR_PERFORM_AUTOTYPE" = "Auto-Type ausführen";
 
 /* Touchbar button label for searching the database */
 "TOUCHBAR_SEARCH" = "Datenbank durchsuchen";
@@ -806,10 +806,10 @@
 "WARNING_CURRENT_DATABASE_FILE_SELECTED_AS_KEY_FILE" = "Die Datenbank kann nicht gleichzeitig als Schlüsseldatei verwendet werden.";
 
 /* Error message displayed when a keepass database file is set as the key file */
-"WARNING_DATABASE_FILE_SELECTED_AS_KEY_FILE" = "Eine andere KeePass Datenbank sollte nicht als Schlüsseldatei verwendet werden. Die Datei kann sich ändern und damit kann die aktuelle Datenbank nicht mehr geöffnet werden.";
+"WARNING_DATABASE_FILE_SELECTED_AS_KEY_FILE" = "Eine andere KeePass-Datenbank sollte nicht als Schlüsseldatei verwendet werden. Die Datei kann sich ändern, und damit kann die aktuelle Datenbank nicht mehr geöffnet werden.";
 
 /* No Key or Password */
-"WARNING_NO_PASSWORD_OR_KEYFILE" = "Kein Passwort und/oder Schlüsseldatei festgelegt!";
+"WARNING_NO_PASSWORD_OR_KEYFILE" = "Weder Passwort noch Schlüsseldatei festgelegt!";
 
 /* Informative Text displayed when clearing the Trash */
 "WARNING_ON_DELETE_TRASHED_NODE_DESCRIPTION" = "Die gewählten Elemente werden dauerhaft aus dem Papierkorb entfernt.";
@@ -827,13 +827,13 @@
 "WARNING_ON_SAVE_NO_PASSWORD_OR_KEY_SET" = "Weder Passwort noch Schlüsseldatei sind festgelegt!";
 
 /* No comment provided by engineer. */
-"WARNING_ON_SAVE_NO_PASSWORD_OR_KEY_SET_SUGGESTION" = "Bitte vergeben Sie ein Passwort und/oder einen Schlüssel. Sofern Sie abbrechen, werden Ihre Änderungen rückgängig gemacht und die Datei gesperrt.";
+"WARNING_ON_SAVE_NO_PASSWORD_OR_KEY_SET_SUGGESTION" = "Bitte vergeben Sie ein Passwort oder einen Schlüssel. Sofern Sie abbrechen, werden Ihre Änderungen rückgängig gemacht und die Datei gesperrt.";
 
 /* Text displayed when no recent documents can be displayed in */
 "WELCOME_WINDOW_NO_RECENT_DOCUMENTS" = "Keine bisherigen Dokumente";
 
 /* Label for the workflow settings tab */
-"WORKFLOW_SETTINGS" = "Arbeitsfluss";
+"WORKFLOW_SETTINGS" = "Arbeitsablauf";
 
 /* Yesterday */
 "YESTERDAY" = "Gestern";

--- a/MacPass/de.lproj/MainMenu.strings
+++ b/MacPass/de.lproj/MainMenu.strings
@@ -137,13 +137,13 @@
 "492.title" = "MacPass-Hilfe";
 
 /* Class = "NSMenuItem"; title = "Toggle Inspector"; ObjectID = "1181"; */
-"1181.title" = "Inspector ein/ausblenden";
+"1181.title" = "Inspector ein-/ausblenden";
 
 /* Class = "NSMenuItem"; title = "Password Generator"; ObjectID = "1200"; */
-"1200.title" = "Passwortgenerator anzeigen";
+"1200.title" = "Passwort-Generator anzeigen";
 
 /* Class = "NSMenuItem"; title = "Change Master Password…"; ObjectID = "1203"; */
-"1203.title" = "Datenbankpasswort ändern …";
+"1203.title" = "Datenbank-Passwort ändern …";
 
 /* Class = "NSMenuItem"; title = "Database Settings…"; ObjectID = "1231"; */
 "1231.title" = "Datenbankeinstellungen …";
@@ -167,7 +167,7 @@
 "HxM-dV-LIH.title" = "Gruppen fokussieren";
 
 /* Class = "NSMenuItem"; title = "Save a Copy…"; ObjectID = "i24-Gn-j9c"; */
-"i24-Gn-j9c.title" = "Kopie Speichern…";
+"i24-Gn-j9c.title" = "Kopie speichern…";
 
 /* Class = "NSMenuItem"; title = "Fix Autotype…"; ObjectID = "nx7-Vf-LiD"; */
 "nx7-Vf-LiD.title" = "Autotype korrigieren …";
@@ -188,11 +188,11 @@
 "Zje-Me-5c8.title" = "Inspektor fokussieren";
 
 /* Class = "NSMenuItem"; title = "Check for Updates…"; ObjectID = "zMO-8r-g5v"; */
-"zMO-8r-g5v.title" = "Nach Updates suchen …";
+"zMO-8r-g5v.title" = "Nach Aktualisierungen suchen …";
 
 /* Class = "NSMenuItem"; title = "Merge With…"; ObjectID = "zvE-0h-UxI"; */
 "zvE-0h-UxI.title" = "Synchronisieren…";
 
 /* Class = "NSMenuItem"; title = "Autotype Doctor"; ObjectID = "zWx-Re-iuJ"; */
-"zWx-Re-iuJ.title" = "Autotype Doktor";
+"zWx-Re-iuJ.title" = "Autotype-Doktor";
 

--- a/MacPass/de.lproj/MainMenu.strings
+++ b/MacPass/de.lproj/MainMenu.strings
@@ -191,7 +191,7 @@
 "zMO-8r-g5v.title" = "Nach Aktualisierungen suchen …";
 
 /* Class = "NSMenuItem"; title = "Merge With…"; ObjectID = "zvE-0h-UxI"; */
-"zvE-0h-UxI.title" = "Synchronisieren…";
+"zvE-0h-UxI.title" = "Zusammenführen mit…";
 
 /* Class = "NSMenuItem"; title = "Autotype Doctor"; ObjectID = "zWx-Re-iuJ"; */
 "zWx-Re-iuJ.title" = "Autotype-Doktor";

--- a/MacPass/de.lproj/OpenPanelAccessoryView.strings
+++ b/MacPass/de.lproj/OpenPanelAccessoryView.strings
@@ -1,6 +1,6 @@
 /* Class = "NSButtonCell"; title = "Show hidden files"; ObjectID = "FfY-KA-8IC"; */
-"FfY-KA-8IC.title" = "Show hidden files";
+"FfY-KA-8IC.title" = "Versteckte Dateien anzeigen";
 
 /* Class = "NSButtonCell"; title = "Allow all files"; ObjectID = "tvV-1s-Be3"; */
-"tvV-1s-Be3.title" = "Allow all files";
+"tvV-1s-Be3.title" = "Alle Dateien zulassen";
 

--- a/MacPass/de.lproj/PasswordCreatorView.strings
+++ b/MacPass/de.lproj/PasswordCreatorView.strings
@@ -5,7 +5,7 @@
 "179.title" = "Länge:";
 
 /* Class = "NSBox"; title = "Character options"; ObjectID = "332"; */
-"332.title" = "Zugelassene Zeichen";
+"332.title" = "Erlaubte Zeichen";
 
 /* Class = "NSButtonCell"; title = "A-Z"; ObjectID = "453"; */
 "453.title" = "A-Z";

--- a/MacPass/de.lproj/PluginDataView.strings
+++ b/MacPass/de.lproj/PluginDataView.strings
@@ -1,5 +1,5 @@
 /* Class = "NSButtonCell"; title = "Remove All"; ObjectID = "6hH-Hc-gf4"; */
-"6hH-Hc-gf4.title" = "Alles Löschen";
+"6hH-Hc-gf4.title" = "Alles löschen";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "bG1-Sb-Xyp"; */
 "bG1-Sb-Xyp.title" = "Text Cell";

--- a/MacPass/de.lproj/ReferenceBuilderView.strings
+++ b/MacPass/de.lproj/ReferenceBuilderView.strings
@@ -11,7 +11,7 @@
 "fNP-ye-2bD.placeholderString" = "Wert";
 
 /* Class = "NSTextFieldCell"; title = "Reference String"; ObjectID = "gik-Ha-hRd"; */
-"gik-Ha-hRd.title" = "Referenz-String";
+"gik-Ha-hRd.title" = "Referenz-Zeichenkette";
 
 /* Class = "NSTextFieldCell"; title = "Key"; ObjectID = "K1t-OZ-ACe"; */
 "K1t-OZ-ACe.title" = "Schlüssel";

--- a/MacPass/en.lproj/Localizable.strings
+++ b/MacPass/en.lproj/Localizable.strings
@@ -47,7 +47,7 @@
 "ALERT_ASK_FOR_PLUGIN_REPOSITORY_CONNECTION_PERMISSION_MESSAGE" = "MacPass would like to check for updates of plugin definitions online";
 
 /* Disallow the download of the plugin repository file */
-"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Do not update defintions";
+"ALERT_ASK_FOR_PLUGIN_REPOSITORY_DISALLOW_DOWNLOAD" = "Do not update definitions";
 
 /* Button in dialog to leave plugin ds disabled and continiue! */
 "ALERT_INCOMPATIBLE_PLUGINS_ENCOUNTERED_BUTTON_OK" = "OK";


### PR DESCRIPTION
In order to do this finally correct, I have to thoroughly test the application and make sure, that the German text really expresses what is meant. For some cases I had to guess the context.

Further, I tried to improved the consistency, like "user" can be "Nutzer" or "Benutzer" (which is gender neutral, in fact, and the Left-or-Green-party-public-broadcast-versions "Nutzer*in" or "Nutzer:in" or "NutzerIn" or "Nutzer_in" or "Nutzende" or "Nutzerinnen und Nutzer" or "Nutzer and Nutzerinnen" or even "Nutzerinnen" or "Nutzerinnen und Nutzerinnen" are located between unnecessary and total nonsense). "Merge" might be "mischen" or here "zusammenführen" or "synchronisieren". Somebody translated "Autotype" with "Auto-Type", but I reverted that as it does not look helpful to me.

So, basically this localisation is not yet perfect and should be tested.