### PR TITLE
fixed autofill on big sur for password field

### DIFF
--- a/MacPass/Base.lproj/EntryInspectorView.xib
+++ b/MacPass/Base.lproj/EntryInspectorView.xib
@@ -362,7 +362,7 @@
                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="249" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C4J-K4-QBG">
                             <rect key="frame" x="0.0" y="188" width="251" height="22"/>
                             <subviews>
-                                <secureTextField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="60" customClass="HNHUISecureTextField">
+                                <secureTextField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" allowsCharacterPickerTouchBarItem="YES" contentType="oneTimeCode" translatesAutoresizingMaskIntoConstraints="NO" id="60" customClass="HNHUISecureTextField">
                                     <rect key="frame" x="0.0" y="1" width="136" height="20"/>
                                     <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="63">
                                         <font key="font" size="13" name="Menlo-Regular"/>


### PR DESCRIPTION
Apple enabled password autofill by default on Big Sur for NSSecureTextField.

This means that by clicking the password field in an entry in MacPass, an annoying "Passwords..." tooltip pops up.

By changing the secure text field's content type to "oneTimeCode", the default behavior is overridden and the autofill feature is disabled.