### PR TITLE
Allow OTP to be copied to paste board.

### DIFF
--- a/MacPass/MPEntryInspectorViewController.m
+++ b/MacPass/MPEntryInspectorViewController.m
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSUInteger, MPEntryTab) {
 - (void)_searchWithGoogleFromMenu:(id)obj;
 @end
 
-@interface MPEntryInspectorViewController () {
+@interface MPEntryInspectorViewController () <MPTOTPViewControllerDelegate> {
 @private
   NSArrayController *_attachmentsController;
   NSArrayController *_customFieldsController;
@@ -600,7 +600,7 @@ typedef NS_ENUM(NSUInteger, MPEntryTab) {
 
 - (void)_setupTOPTView {
   self.totpViewController = [[MPTOTPViewController alloc] init];
-  
+  self.totpViewController.delegate = self;
   NSInteger urlindex = [self.fieldsStackView.arrangedSubviews indexOfObject:self.URLTextField];
   NSAssert(urlindex != NSNotFound, @"Missing reference view. This should not happen!");
   [self addChildViewController:self.totpViewController];
@@ -699,6 +699,13 @@ typedef NS_ENUM(NSUInteger, MPEntryTab) {
 #pragma mark KPKEntry Notifications
 
 - (void)_didChangeAttribute:(NSNotification *)notification {
+}
+
+#pragma mark -
+#pragma mark MPTOTPViewControllerDelegate
+
+- (void)didCopyTOTPString:(NSString *)string {
+  [MPPasteBoardController.defaultController copyObject:string overlayInfo:MPPasteboardOverlayInfoOTP name:@"" atView:self.view];
 }
 
 @end

--- a/MacPass/MPPasteBoardController.h
+++ b/MacPass/MPPasteBoardController.h
@@ -25,6 +25,7 @@
 typedef NS_ENUM(NSUInteger, MPPasteboardOverlayInfoType) {
   MPPasteboardOverlayInfoPassword,
   MPPasteboardOverlayInfoUsername,
+  MPPasteboardOverlayInfoOTP,
   MPPasteboardOverlayInfoURL,
   MPPasteboardOverlayInfoCustom, // overlay info that a custom field was copied
   MPPasteboardOverlayInfoReference // overlay info that a reference that was copied

--- a/MacPass/MPPasteBoardController.m
+++ b/MacPass/MPPasteBoardController.m
@@ -139,6 +139,11 @@ NSString *const MPPasteBoardTypeSource          = @"org.nspasteboard.source";
       infoText = NSLocalizedString(@"COPIED_PASSWORD", @"Password was copied to the pasteboard");
       break;
       
+    case MPPasteboardOverlayInfoOTP:
+      infoImage = [NSBundle.mainBundle imageForResource:@"00_PasswordTemplate"];
+      infoText = NSLocalizedString(@"COPIED_OTP", @"OTP was copied to the pasteboard");
+      break;
+
     case MPPasteboardOverlayInfoURL:
       infoImage = [NSBundle.mainBundle imageForResource:@"01_PackageNetworkTemplate"];
       infoText = NSLocalizedString(@"COPIED_URL", @"URL was copied to the pasteboard");

--- a/MacPass/MPTOTPViewController.h
+++ b/MacPass/MPTOTPViewController.h
@@ -11,10 +11,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol MPTOTPViewControllerDelegate <NSObject>
+
+@optional
+- (void)didCopyTOTPString:(NSString *)string;
+
+@end
+
 @interface MPTOTPViewController : NSViewController
 @property (strong) IBOutlet HNHUITextField *toptValueTextField;
 @property (strong) IBOutlet NSButton *remainingTimeButton;
 @property (strong) IBOutlet NSButton *showSetupButton;
+@property (nullable, weak) id<MPTOTPViewControllerDelegate> delegate;
 
 @end
 

--- a/MacPass/MPTOTPViewController.m
+++ b/MacPass/MPTOTPViewController.m
@@ -20,7 +20,9 @@
 @implementation MPTOTPViewController
 
 - (void)viewDidLoad {
+  [super viewDidLoad];
   self.remainingTimeButton.title = @"";
+  [self _setupTOPTView];
 }
 
 - (IBAction)showOTPSetup:(id)sender {
@@ -68,5 +70,15 @@
     self.remainingTimeButton.title = @"";
     self.toptValueTextField.stringValue = @"";
   }
+}
+
+- (void)_setupTOPTView {
+  __weak __typeof__(self) weakSelf = self;
+  self.toptValueTextField.copyActionBlock = ^(NSTextField *textField) {
+    __strong __typeof__(weakSelf) strongSelf = weakSelf;
+    if ([strongSelf.delegate respondsToSelector:@selector(didCopyTOTPString:)]) {
+      [strongSelf.delegate didCopyTOTPString:textField.stringValue];
+    }
+  };
 }
 @end

--- a/MacPass/en.lproj/Localizable.strings
+++ b/MacPass/en.lproj/Localizable.strings
@@ -198,6 +198,9 @@
 /* Context menu that copies reference to title */
 "COPIED_TITLE_REFERENCE" = "Reference to title copied!";
 
+/* OTP was copied to the pasteboard */
+"COPIED_OTP" = "OTP copied!";
+
 /* URL was copied to the pasteboard */
 "COPIED_URL" = "URL copied!";
 


### PR DESCRIPTION
First off I would like to say great work with MacPass! I have been very pleased to see the addition of OTP. One feature I miss from another password manager is the ability to copy the OTP. I realize other fields allow selection but they also allow editing. As OTP is generated and not editable this approach made sense to me. I also realize I may not be following approaches established in this project so please provide feedback where necessary. 


<img width="800" alt="copyotp" src="https://user-images.githubusercontent.com/1231767/126884439-275473aa-7a35-4a4f-97af-b7bef6b1733d.png">
