### PR TITLE
Hotkey with search option

### DIFF
--- a/MacPass.xcodeproj/project.pbxproj
+++ b/MacPass.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		6021FE9818E1650F00C3BC51 /* DatabaseSettingsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6021FE9A18E1650F00C3BC51 /* DatabaseSettingsWindow.xib */; };
 		7837112C225540D1009BD28D /* PluginRepositoryBrowserView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7837112E225540D1009BD28D /* PluginRepositoryBrowserView.xib */; };
 		78E1F8B022E3A5D600E738AE /* AutotypeDoctorReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 78E1F8B222E3A5D600E738AE /* AutotypeDoctorReportViewController.xib */; };
+		7E5D230927889AE400C0ECCF /* MPHotkey.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E5D230827889AE400C0ECCF /* MPHotkey.m */; };
 		FA13910C1F9CD9EB0033D256 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = FA13910A1F9CD9EB0033D256 /* Localizable.stringsdict */; };
 		FA9FD3271FB5E8F4003CEDD6 /* AutotypeCandidateSelectionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA9FD3291FB5E8F4003CEDD6 /* AutotypeCandidateSelectionView.xib */; };
 		FA9FD32C1FB5EDD3003CEDD6 /* AutotypeBuilderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA9FD32E1FB5EDD3003CEDD6 /* AutotypeBuilderView.xib */; };
@@ -1095,6 +1096,8 @@
 		78E1F8BE22E3B1BF00E738AE /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/AutotypeCandidateSelectionView.strings; sourceTree = "<group>"; };
 		78E1F8C022E3B22500E738AE /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/PluginDataView.strings; sourceTree = "<group>"; };
 		78E1F8C122E3B32D00E738AE /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ru; path = ru.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		7E5D230727889ACE00C0ECCF /* MPHotkey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPHotkey.h; sourceTree = "<group>"; };
+		7E5D230827889AE400C0ECCF /* MPHotkey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPHotkey.m; sourceTree = "<group>"; };
 		A019D80F22DC6B3C0085FD54 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = es; path = es.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		A083E27922DF467B0020E0D5 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PickcharsView.strings; sourceTree = "<group>"; };
 		A083E27A22DF467B0020E0D5 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PluginDataView.strings; sourceTree = "<group>"; };
@@ -1337,6 +1340,8 @@
 		4C2E382016D141F700037A9D /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				7E5D230727889ACE00C0ECCF /* MPHotkey.h */,
+				7E5D230827889AE400C0ECCF /* MPHotkey.m */,
 				4C888C9516EB754B003D34A1 /* MPActionHelper.h */,
 				4C888C9616EB754B003D34A1 /* MPActionHelper.m */,
 				4C01C2401764D8980016D5D0 /* MPContextMenuHelper.h */,
@@ -2276,6 +2281,7 @@
 				4C3BD51516D276F800389F1F /* MPToolbarDelegate.m in Sources */,
 				4C8F0C711FCEF91400BE157F /* MPPickcharsParser.m in Sources */,
 				4C735FC02035FCBF00708D53 /* MPPluginEntryActionContext.m in Sources */,
+				7E5D230927889AE400C0ECCF /* MPHotkey.m in Sources */,
 				4C61EA0316D2FD0800AC519E /* MPOutlineViewController.m in Sources */,
 				4C65C79C16DD283900E32CFF /* MPToolbarButton.m in Sources */,
 				4C49CFD624252389004092E7 /* KPKEntry+MPTags.m in Sources */,
@@ -2724,7 +2730,6 @@
 				4C9328D1273E6A83000DCBEE /* Base */,
 				4C9328D4273E6A85000DCBEE /* zh-Hans */,
 				4C9328D6273E6A85000DCBEE /* de */,
-				69385E36274ACFDF001AB1E9 /* cs */,
 			);
 			name = MPTOTPViewController.xib;
 			sourceTree = "<group>";
@@ -2753,7 +2758,6 @@
 			isa = PBXVariantGroup;
 			children = (
 				4CF14962224B623700D1CE1C /* Base */,
-				69385E4F274ACFE0001AB1E9 /* cs */,
 			);
 			name = Credits.rtf;
 			sourceTree = "<group>";

--- a/MacPass/Base.lproj/IntegrationPreferences.xib
+++ b/MacPass/Base.lproj/IntegrationPreferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,19 +27,19 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="411" height="520"/>
+            <rect key="frame" x="0.0" y="0.0" width="417" height="535"/>
             <subviews>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="500" borderType="line" title="Autotype" translatesAutoresizingMaskIntoConstraints="NO" id="P9N-HM-wER">
-                    <rect key="frame" x="17" y="115" width="377" height="385"/>
+                    <rect key="frame" x="17" y="117" width="383" height="398"/>
                     <view key="contentView" id="faU-Ok-HJ3">
-                        <rect key="frame" x="3" y="3" width="371" height="367"/>
+                        <rect key="frame" x="3" y="3" width="377" height="380"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="j52-9L-k7c">
-                                <rect key="frame" x="16" y="17" width="339" height="340"/>
+                                <rect key="frame" x="16" y="17" width="345" height="353"/>
                                 <subviews>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="hMJ-Mo-xOM">
-                                        <rect key="frame" x="-2" y="298" width="343" height="42"/>
+                                        <rect key="frame" x="-2" y="311" width="349" height="42"/>
                                         <textFieldCell key="cell" controlSize="small" id="H37-ku-aTc">
                                             <font key="font" metaFont="smallSystem"/>
                                             <string key="title">Autotype might not work properly. Some issues where found that prevent Autotype or Global Autotype to work. Please run the Autotype Doctor to fix those issues.</string>
@@ -48,7 +48,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jai-b6-Qv4">
-                                        <rect key="frame" x="-6" y="262" width="177" height="32"/>
+                                        <rect key="frame" x="-7" y="276" width="171" height="32"/>
                                         <buttonCell key="cell" type="push" title="Run Autotype Doctor…" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="NP0-R3-m6n">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -58,14 +58,14 @@
                                         </connections>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="tik-Ar-FJg">
-                                        <rect key="frame" x="-2" y="245" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="258" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Enable global Autotype" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1qb-Rd-jYu">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="d6A-Vb-CMt">
-                                        <rect key="frame" x="0.0" y="218" width="281" height="21"/>
+                                        <rect key="frame" x="0.0" y="230" width="281" height="21"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buI-Wb-o3V">
                                                 <rect key="frame" x="-2" y="3" width="57" height="16"/>
@@ -107,14 +107,14 @@
                                         </customSpacing>
                                     </stackView>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uZQ-Gd-hfu">
-                                        <rect key="frame" x="-2" y="194" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="205" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Always show confirmation before executing Autotype" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rrU-70-Ara">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cUt-aB-oib">
-                                        <rect key="frame" x="-2" y="146" width="343" height="42"/>
+                                        <rect key="frame" x="-2" y="156" width="349" height="42"/>
                                         <textFieldCell key="cell" controlSize="small" selectable="YES" id="VjU-Hz-cu4">
                                             <font key="font" metaFont="smallSystem"/>
                                             <string key="title">If enabled, a dialog will show up before Autotype is executed even if only a single match was found to prevent accidental input and wrong matches</string>
@@ -123,42 +123,42 @@
                                         </textFieldCell>
                                     </textField>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="DAX-V8-Say">
-                                        <rect key="frame" x="-2" y="122" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="131" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry Title for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tmL-dT-D0G">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="8Wz-lo-AXG">
-                                        <rect key="frame" x="-2" y="100" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="107" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry URL for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="TzR-00-Vp3">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="TiO-ah-BlR">
-                                        <rect key="frame" x="-2" y="78" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="83" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry URL Host for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="B1D-j9-L8x">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="9MH-jx-GpG">
-                                        <rect key="frame" x="-2" y="56" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="59" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Include Entry Tags for matches" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rbu-G7-MT8">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VK8-z4-2ci">
-                                        <rect key="frame" x="-2" y="34" width="343" height="18"/>
+                                        <rect key="frame" x="-2" y="35" width="347" height="18"/>
                                         <buttonCell key="cell" type="check" title="Interpret ⌃ as ⌘" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QfO-yG-l3F">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="wbP-A9-jpw">
-                                        <rect key="frame" x="-2" y="0.0" width="343" height="28"/>
+                                        <rect key="frame" x="-2" y="0.0" width="349" height="28"/>
                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="If enabled, every {CONTROL} command will be sent as ⌘. Only disable this if you are sure you need to." id="QRy-CY-ENC">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -205,20 +205,20 @@
                     </constraints>
                 </box>
                 <box autoresizesSubviews="NO" verticalHuggingPriority="500" borderType="line" title="Preview" translatesAutoresizingMaskIntoConstraints="NO" id="VVs-b5-cX9">
-                    <rect key="frame" x="17" y="16" width="377" height="95"/>
+                    <rect key="frame" x="17" y="16" width="383" height="97"/>
                     <view key="contentView" id="ww4-uR-8gP">
-                        <rect key="frame" x="3" y="3" width="371" height="77"/>
+                        <rect key="frame" x="3" y="3" width="377" height="79"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="LNw-5t-TS4">
-                                <rect key="frame" x="14" y="51" width="178" height="18"/>
+                                <rect key="frame" x="14" y="52" width="182" height="18"/>
                                 <buttonCell key="cell" type="check" title="Enable Quicklook Preview" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ERs-ct-Eyx">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="V6l-R9-hIj">
-                                <rect key="frame" x="14" y="17" width="343" height="28"/>
+                                <rect key="frame" x="14" y="17" width="349" height="28"/>
                                 <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="If enabled attached files will be copied to a temporary location for preview and deleted after the preview is closed." id="WmI-IB-Aso">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>

--- a/MacPass/Base.lproj/WorkflowPreferences.xib
+++ b/MacPass/Base.lproj/WorkflowPreferences.xib
@@ -23,8 +23,8 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="449" height="564"/>
+        <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="449" height="586"/>
             <subviews>
                 <box autoresizesSubviews="NO" horizontalHuggingPriority="249" verticalHuggingPriority="500" borderType="line" title="Entry Table" translatesAutoresizingMaskIntoConstraints="NO" id="2">
                     <rect key="frame" x="17" y="358" width="415" height="104"/>
@@ -209,14 +209,14 @@
                         </constraints>
                     </view>
                 </box>
-                <box title="Show/Hide" translatesAutoresizingMaskIntoConstraints="NO" id="mpG-iq-bhB">
-                    <rect key="frame" x="17" y="16" width="415" height="82"/>
+                <box misplaced="YES" title="Show/Hide" translatesAutoresizingMaskIntoConstraints="NO" id="mpG-iq-bhB">
+                    <rect key="frame" x="17" y="16" width="415" height="104"/>
                     <view key="contentView" id="R3w-li-WA8">
-                        <rect key="frame" x="3" y="3" width="409" height="64"/>
+                        <rect key="frame" x="3" y="3" width="409" height="86"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button horizontalHuggingPriority="249" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z3J-5h-Kcn">
-                                <rect key="frame" x="18" y="39" width="347" height="18"/>
+                                <rect key="frame" x="18" y="61" width="347" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Enable hotkey to Show or Hide" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="L0R-mC-Agn">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -224,7 +224,7 @@
                                 </buttonCell>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Srb-DZ-qGe">
-                                <rect key="frame" x="48" y="17" width="57" height="16"/>
+                                <rect key="frame" x="48" y="39" width="57" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut" id="fNT-m3-Gh9">
                                     <font key="font" metaFont="system"/>
@@ -233,7 +233,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ndS-10-Cli" customClass="DDHotKeyTextField">
-                                <rect key="frame" x="111" y="14" width="89" height="21"/>
+                                <rect key="frame" x="111" y="36" width="89" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="89" id="7jX-CO-3jH"/>
                                 </constraints>
@@ -244,7 +244,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ao4-0o-oyc">
-                                <rect key="frame" x="206" y="18" width="127" height="14"/>
+                                <rect key="frame" x="206" y="40" width="127" height="14"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut is missing Key" id="Z1b-ek-Rtf">
                                     <font key="font" metaFont="smallSystem"/>
@@ -252,6 +252,14 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <button horizontalHuggingPriority="249" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0qq-3C-pMA">
+                                <rect key="frame" x="48" y="11" width="347" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Focus Search after hotkey trigger" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Q4M-FK-EGO">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
                         </subviews>
                     </view>
                 </box>
@@ -279,7 +287,7 @@
                 <constraint firstItem="CLc-Vg-aWg" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="wyw-aC-Vkj"/>
                 <constraint firstItem="8Z8-mS-hfg" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="xdM-IO-cz3"/>
             </constraints>
-            <point key="canvasLocation" x="-906.5" y="-157"/>
+            <point key="canvasLocation" x="-906.5" y="-146"/>
         </customView>
     </objects>
 </document>

--- a/MacPass/Base.lproj/WorkflowPreferences.xib
+++ b/MacPass/Base.lproj/WorkflowPreferences.xib
@@ -14,6 +14,9 @@
                 <outlet property="focusSearchAfterUnlockCheckButton" destination="VIS-db-Y8n" id="xVr-wf-eJg"/>
                 <outlet property="generatePasswordOnEntriesCheckButton" destination="yxq-YK-61i" id="0SK-CT-Wdn"/>
                 <outlet property="hideAfterCopyToClipboardCheckButton" destination="vT4-wF-ned" id="d7e-vc-cAQ"/>
+                <outlet property="hotkeyTextField" destination="ndS-10-Cli" id="O3k-MO-6SJ"/>
+                <outlet property="hotkeyWarningTextField" destination="ao4-0o-oyc" id="2pl-bi-680"/>
+                <outlet property="showOrHideMacPassCheckButton" destination="z3J-5h-Kcn" id="sie-VB-LZr"/>
                 <outlet property="updatePasswordOnTemplateEntriesCheckButton" destination="LPY-sM-hjS" id="wav-op-uck"/>
                 <outlet property="view" destination="1" id="52"/>
             </connections>
@@ -21,10 +24,10 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="449" height="478"/>
+            <rect key="frame" x="0.0" y="0.0" width="449" height="564"/>
             <subviews>
                 <box autoresizesSubviews="NO" horizontalHuggingPriority="249" verticalHuggingPriority="500" borderType="line" title="Entry Table" translatesAutoresizingMaskIntoConstraints="NO" id="2">
-                    <rect key="frame" x="17" y="272" width="415" height="104"/>
+                    <rect key="frame" x="17" y="358" width="415" height="104"/>
                     <view key="contentView" id="cfa-nq-Kzt">
                         <rect key="frame" x="3" y="3" width="409" height="86"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -92,7 +95,7 @@
                     </constraints>
                 </box>
                 <box horizontalHuggingPriority="249" borderType="line" title="New Entries" translatesAutoresizingMaskIntoConstraints="NO" id="Xvt-tP-TbR">
-                    <rect key="frame" x="17" y="172" width="415" height="96"/>
+                    <rect key="frame" x="17" y="258" width="415" height="96"/>
                     <view key="contentView" id="g0i-00-sng">
                         <rect key="frame" x="3" y="3" width="409" height="78"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -124,7 +127,7 @@
                     </view>
                 </box>
                 <box horizontalHuggingPriority="249" title="Clipboard" translatesAutoresizingMaskIntoConstraints="NO" id="Kff-Xp-hAT">
-                    <rect key="frame" x="17" y="94" width="415" height="74"/>
+                    <rect key="frame" x="17" y="180" width="415" height="74"/>
                     <view key="contentView" id="Ntf-zj-VZL">
                         <rect key="frame" x="3" y="3" width="409" height="56"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -146,7 +149,7 @@
                     </view>
                 </box>
                 <box title="Search" translatesAutoresizingMaskIntoConstraints="NO" id="CLc-Vg-aWg">
-                    <rect key="frame" x="17" y="16" width="415" height="74"/>
+                    <rect key="frame" x="17" y="102" width="415" height="74"/>
                     <view key="contentView" id="KWW-Ss-mhI">
                         <rect key="frame" x="3" y="3" width="409" height="56"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -168,7 +171,7 @@
                     </view>
                 </box>
                 <box title="URLs" translatesAutoresizingMaskIntoConstraints="NO" id="8Z8-mS-hfg">
-                    <rect key="frame" x="17" y="380" width="415" height="78"/>
+                    <rect key="frame" x="17" y="466" width="415" height="78"/>
                     <view key="contentView" id="LD4-oH-eGw">
                         <rect key="frame" x="3" y="3" width="409" height="60"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -206,15 +209,63 @@
                         </constraints>
                     </view>
                 </box>
+                <box title="Show/Hide" translatesAutoresizingMaskIntoConstraints="NO" id="mpG-iq-bhB">
+                    <rect key="frame" x="17" y="16" width="415" height="82"/>
+                    <view key="contentView" id="R3w-li-WA8">
+                        <rect key="frame" x="3" y="3" width="409" height="64"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button horizontalHuggingPriority="249" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z3J-5h-Kcn">
+                                <rect key="frame" x="18" y="39" width="347" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Enable hotkey to Show or Hide" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="L0R-mC-Agn">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Srb-DZ-qGe">
+                                <rect key="frame" x="48" y="17" width="57" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut" id="fNT-m3-Gh9">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ndS-10-Cli" customClass="DDHotKeyTextField">
+                                <rect key="frame" x="111" y="14" width="89" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="89" id="7jX-CO-3jH"/>
+                                </constraints>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="" drawsBackground="YES" id="Le3-HF-bvk" customClass="DDHotKeyTextFieldCell">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ao4-0o-oyc">
+                                <rect key="frame" x="206" y="18" width="127" height="14"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut is missing Key" id="Z1b-ek-Rtf">
+                                    <font key="font" metaFont="smallSystem"/>
+                                    <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                    </view>
+                </box>
             </subviews>
             <constraints>
                 <constraint firstItem="2" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="5"/>
                 <constraint firstAttribute="trailing" secondItem="2" secondAttribute="trailing" constant="20" symbolic="YES" id="8"/>
-                <constraint firstAttribute="bottom" secondItem="CLc-Vg-aWg" secondAttribute="bottom" constant="20" symbolic="YES" id="1VG-9p-VC6"/>
+                <constraint firstItem="mpG-iq-bhB" firstAttribute="bottom" secondItem="1" secondAttribute="bottom" constant="-20" id="1VG-9p-VC6"/>
                 <constraint firstItem="Kff-Xp-hAT" firstAttribute="top" secondItem="Xvt-tP-TbR" secondAttribute="bottom" constant="8" symbolic="YES" id="3RL-tm-4wu"/>
                 <constraint firstAttribute="trailing" secondItem="8Z8-mS-hfg" secondAttribute="trailing" constant="20" symbolic="YES" id="5Hg-na-QAc"/>
+                <constraint firstAttribute="height" secondItem="mpG-iq-bhB" secondAttribute="height" multiplier="7.23077" id="90F-ub-nN3"/>
                 <constraint firstItem="Xvt-tP-TbR" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="BH4-4y-uma"/>
                 <constraint firstItem="Xvt-tP-TbR" firstAttribute="top" secondItem="2" secondAttribute="bottom" constant="8" symbolic="YES" id="FVK-Uf-kLv"/>
+                <constraint firstAttribute="height" constant="564" id="KQg-ar-5iV"/>
                 <constraint firstItem="CLc-Vg-aWg" firstAttribute="top" secondItem="Kff-Xp-hAT" secondAttribute="bottom" constant="8" symbolic="YES" id="MZ9-vN-2za"/>
                 <constraint firstItem="8Z8-mS-hfg" firstAttribute="top" secondItem="1" secondAttribute="top" constant="20" symbolic="YES" id="ScX-YY-rgS"/>
                 <constraint firstAttribute="trailing" secondItem="Kff-Xp-hAT" secondAttribute="trailing" constant="20" symbolic="YES" id="VLC-2A-Vdd"/>
@@ -222,10 +273,13 @@
                 <constraint firstItem="2" firstAttribute="top" secondItem="8Z8-mS-hfg" secondAttribute="bottom" constant="8" symbolic="YES" id="Z6D-RB-aR5"/>
                 <constraint firstAttribute="trailing" secondItem="Xvt-tP-TbR" secondAttribute="trailing" constant="20" id="anU-nC-YAw"/>
                 <constraint firstAttribute="trailing" secondItem="CLc-Vg-aWg" secondAttribute="trailing" constant="20" symbolic="YES" id="fXu-pq-O8Q"/>
+                <constraint firstAttribute="trailing" secondItem="mpG-iq-bhB" secondAttribute="trailing" constant="20" symbolic="YES" id="gi4-jv-uIS"/>
+                <constraint firstItem="mpG-iq-bhB" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="p1V-P9-mcG"/>
+                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="564" id="pZq-NN-J9o"/>
                 <constraint firstItem="CLc-Vg-aWg" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="wyw-aC-Vkj"/>
                 <constraint firstItem="8Z8-mS-hfg" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="xdM-IO-cz3"/>
             </constraints>
-            <point key="canvasLocation" x="-906.5" y="-199.5"/>
+            <point key="canvasLocation" x="-906.5" y="-157"/>
         </customView>
     </objects>
 </document>

--- a/MacPass/Base.lproj/WorkflowPreferences.xib
+++ b/MacPass/Base.lproj/WorkflowPreferences.xib
@@ -11,6 +11,7 @@
                 <outlet property="browserPopup" destination="ehI-gq-lsb" id="YMy-L1-pQw"/>
                 <outlet property="doubleClickTitlePopup" destination="40" id="aKJ-q9-xjb"/>
                 <outlet property="doubleClickURLPopup" destination="13" id="fGP-5I-0XK"/>
+                <outlet property="focusSearchAfterHotkey" destination="Q4M-FK-EGO" id="pMU-Tl-eis"/>
                 <outlet property="focusSearchAfterUnlockCheckButton" destination="VIS-db-Y8n" id="xVr-wf-eJg"/>
                 <outlet property="generatePasswordOnEntriesCheckButton" destination="yxq-YK-61i" id="0SK-CT-Wdn"/>
                 <outlet property="hideAfterCopyToClipboardCheckButton" destination="vT4-wF-ned" id="d7e-vc-cAQ"/>
@@ -24,10 +25,10 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="449" height="586"/>
+            <rect key="frame" x="0.0" y="0.0" width="449" height="602"/>
             <subviews>
-                <box autoresizesSubviews="NO" horizontalHuggingPriority="249" verticalHuggingPriority="500" borderType="line" title="Entry Table" translatesAutoresizingMaskIntoConstraints="NO" id="2">
-                    <rect key="frame" x="17" y="358" width="415" height="104"/>
+                <box autoresizesSubviews="NO" horizontalHuggingPriority="249" verticalHuggingPriority="500" ambiguous="YES" borderType="line" title="Entry Table" translatesAutoresizingMaskIntoConstraints="NO" id="2">
+                    <rect key="frame" x="17" y="396" width="415" height="104"/>
                     <view key="contentView" id="cfa-nq-Kzt">
                         <rect key="frame" x="3" y="3" width="409" height="86"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -94,20 +95,20 @@
                         <constraint firstItem="40" firstAttribute="leading" secondItem="36" secondAttribute="trailing" constant="8" symbolic="YES" id="tsy-wg-saI"/>
                     </constraints>
                 </box>
-                <box horizontalHuggingPriority="249" borderType="line" title="New Entries" translatesAutoresizingMaskIntoConstraints="NO" id="Xvt-tP-TbR">
-                    <rect key="frame" x="17" y="258" width="415" height="96"/>
-                    <view key="contentView" id="g0i-00-sng">
+                <box horizontalHuggingPriority="249" ambiguous="YES" borderType="line" title="New Entries" translatesAutoresizingMaskIntoConstraints="NO" id="Xvt-tP-TbR">
+                    <rect key="frame" x="17" y="296" width="415" height="96"/>
+                    <view key="contentView" ambiguous="YES" id="g0i-00-sng">
                         <rect key="frame" x="3" y="3" width="409" height="78"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LPY-sM-hjS">
+                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LPY-sM-hjS">
                                 <rect key="frame" x="18" y="41" width="354" height="18"/>
                                 <buttonCell key="cell" type="check" title="Generate password for entries created from templates" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="RaM-t2-DVR">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yxq-YK-61i">
+                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yxq-YK-61i">
                                 <rect key="frame" x="18" y="19" width="238" height="18"/>
                                 <buttonCell key="cell" type="check" title="Generate password for new entries" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="iCq-mG-p81">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -126,13 +127,13 @@
                         </constraints>
                     </view>
                 </box>
-                <box horizontalHuggingPriority="249" title="Clipboard" translatesAutoresizingMaskIntoConstraints="NO" id="Kff-Xp-hAT">
-                    <rect key="frame" x="17" y="180" width="415" height="74"/>
-                    <view key="contentView" id="Ntf-zj-VZL">
+                <box horizontalHuggingPriority="249" ambiguous="YES" title="Clipboard" translatesAutoresizingMaskIntoConstraints="NO" id="Kff-Xp-hAT">
+                    <rect key="frame" x="17" y="218" width="415" height="74"/>
+                    <view key="contentView" ambiguous="YES" id="Ntf-zj-VZL">
                         <rect key="frame" x="3" y="3" width="409" height="56"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vT4-wF-ned">
+                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vT4-wF-ned">
                                 <rect key="frame" x="18" y="19" width="284" height="18"/>
                                 <buttonCell key="cell" type="check" title="Hide application after copying to clipboard" bezelStyle="regularSquare" imagePosition="left" inset="2" id="1Vr-nY-Ogv">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -148,13 +149,13 @@
                         </constraints>
                     </view>
                 </box>
-                <box title="Search" translatesAutoresizingMaskIntoConstraints="NO" id="CLc-Vg-aWg">
-                    <rect key="frame" x="17" y="102" width="415" height="74"/>
-                    <view key="contentView" id="KWW-Ss-mhI">
+                <box ambiguous="YES" title="Search" translatesAutoresizingMaskIntoConstraints="NO" id="CLc-Vg-aWg">
+                    <rect key="frame" x="17" y="140" width="415" height="74"/>
+                    <view key="contentView" ambiguous="YES" id="KWW-Ss-mhI">
                         <rect key="frame" x="3" y="3" width="409" height="56"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VIS-db-Y8n">
+                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VIS-db-Y8n">
                                 <rect key="frame" x="18" y="19" width="261" height="18"/>
                                 <buttonCell key="cell" type="check" title="Focus search after unlocking database" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="I0s-iS-0Sc">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -170,13 +171,13 @@
                         </constraints>
                     </view>
                 </box>
-                <box title="URLs" translatesAutoresizingMaskIntoConstraints="NO" id="8Z8-mS-hfg">
-                    <rect key="frame" x="17" y="466" width="415" height="78"/>
-                    <view key="contentView" id="LD4-oH-eGw">
+                <box ambiguous="YES" title="URLs" translatesAutoresizingMaskIntoConstraints="NO" id="8Z8-mS-hfg">
+                    <rect key="frame" x="17" y="504" width="415" height="78"/>
+                    <view key="contentView" ambiguous="YES" id="LD4-oH-eGw">
                         <rect key="frame" x="3" y="3" width="409" height="60"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lOo-NI-b07">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lOo-NI-b07">
                                 <rect key="frame" x="18" y="23" width="91" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Open URLs in:" id="soD-wI-YOH">
                                     <font key="font" metaFont="system"/>
@@ -184,7 +185,7 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ehI-gq-lsb">
+                            <popUpButton verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ehI-gq-lsb">
                                 <rect key="frame" x="112" y="16" width="136" height="25"/>
                                 <popUpButtonCell key="cell" type="push" title="Default Browser" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="7YX-EA-9KA" id="7Ip-sU-sAK">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -209,22 +210,21 @@
                         </constraints>
                     </view>
                 </box>
-                <box misplaced="YES" title="Show/Hide" translatesAutoresizingMaskIntoConstraints="NO" id="mpG-iq-bhB">
-                    <rect key="frame" x="17" y="16" width="415" height="104"/>
-                    <view key="contentView" id="R3w-li-WA8">
-                        <rect key="frame" x="3" y="3" width="409" height="86"/>
+                <box ambiguous="YES" title="Show/Hide" translatesAutoresizingMaskIntoConstraints="NO" id="mpG-iq-bhB">
+                    <rect key="frame" x="17" y="16" width="415" height="120"/>
+                    <view key="contentView" ambiguous="YES" id="R3w-li-WA8">
+                        <rect key="frame" x="3" y="3" width="409" height="102"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button horizontalHuggingPriority="249" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z3J-5h-Kcn">
-                                <rect key="frame" x="18" y="61" width="347" height="18"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="check" title="Enable hotkey to Show or Hide" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="L0R-mC-Agn">
+                            <button horizontalHuggingPriority="249" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z3J-5h-Kcn">
+                                <rect key="frame" x="18" y="75" width="347" height="18"/>
+                                <buttonCell key="cell" type="check" title="Enable hotkey to Show or Hide" bezelStyle="regularSquare" imagePosition="left" inset="2" id="L0R-mC-Agn">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Srb-DZ-qGe">
-                                <rect key="frame" x="48" y="39" width="57" height="16"/>
+                                <rect key="frame" x="47" y="46" width="57" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut" id="fNT-m3-Gh9">
                                     <font key="font" metaFont="system"/>
@@ -232,8 +232,24 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ao4-0o-oyc">
+                                <rect key="frame" x="205" y="47" width="127" height="14"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut is missing Key" id="Z1b-ek-Rtf">
+                                    <font key="font" metaFont="smallSystem"/>
+                                    <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button horizontalHuggingPriority="249" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0qq-3C-pMA">
+                                <rect key="frame" x="48" y="15" width="347" height="18"/>
+                                <buttonCell key="cell" type="check" title="Focus Search after hotkey trigger" bezelStyle="regularSquare" imagePosition="left" enabled="NO" inset="2" id="Q4M-FK-EGO">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
                             <textField verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ndS-10-Cli" customClass="DDHotKeyTextField">
-                                <rect key="frame" x="111" y="36" width="89" height="21"/>
+                                <rect key="frame" x="110" y="44" width="89" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="89" id="7jX-CO-3jH"/>
                                 </constraints>
@@ -243,34 +259,21 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ao4-0o-oyc">
-                                <rect key="frame" x="206" y="40" width="127" height="14"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut is missing Key" id="Z1b-ek-Rtf">
-                                    <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <button horizontalHuggingPriority="249" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0qq-3C-pMA">
-                                <rect key="frame" x="48" y="11" width="347" height="18"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="check" title="Focus Search after hotkey trigger" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Q4M-FK-EGO">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                            </button>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="z3J-5h-Kcn" firstAttribute="top" secondItem="R3w-li-WA8" secondAttribute="top" constant="8" id="c5Q-Lx-9Gf"/>
+                            <constraint firstItem="0qq-3C-pMA" firstAttribute="top" secondItem="ndS-10-Cli" secondAttribute="bottom" constant="12" id="kv7-pr-xzZ"/>
+                            <constraint firstItem="ndS-10-Cli" firstAttribute="top" secondItem="z3J-5h-Kcn" secondAttribute="bottom" constant="-25" id="sNG-ps-IZS"/>
+                            <constraint firstAttribute="bottom" secondItem="0qq-3C-pMA" secondAttribute="bottom" constant="17" id="yDS-iO-Ih6"/>
+                        </constraints>
                     </view>
                 </box>
             </subviews>
             <constraints>
                 <constraint firstItem="2" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="5"/>
                 <constraint firstAttribute="trailing" secondItem="2" secondAttribute="trailing" constant="20" symbolic="YES" id="8"/>
-                <constraint firstItem="mpG-iq-bhB" firstAttribute="bottom" secondItem="1" secondAttribute="bottom" constant="-20" id="1VG-9p-VC6"/>
                 <constraint firstItem="Kff-Xp-hAT" firstAttribute="top" secondItem="Xvt-tP-TbR" secondAttribute="bottom" constant="8" symbolic="YES" id="3RL-tm-4wu"/>
                 <constraint firstAttribute="trailing" secondItem="8Z8-mS-hfg" secondAttribute="trailing" constant="20" symbolic="YES" id="5Hg-na-QAc"/>
-                <constraint firstAttribute="height" secondItem="mpG-iq-bhB" secondAttribute="height" multiplier="7.23077" id="90F-ub-nN3"/>
                 <constraint firstItem="Xvt-tP-TbR" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="BH4-4y-uma"/>
                 <constraint firstItem="Xvt-tP-TbR" firstAttribute="top" secondItem="2" secondAttribute="bottom" constant="8" symbolic="YES" id="FVK-Uf-kLv"/>
                 <constraint firstAttribute="height" constant="564" id="KQg-ar-5iV"/>
@@ -280,14 +283,16 @@
                 <constraint firstItem="Kff-Xp-hAT" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="Vle-Z0-mh8"/>
                 <constraint firstItem="2" firstAttribute="top" secondItem="8Z8-mS-hfg" secondAttribute="bottom" constant="8" symbolic="YES" id="Z6D-RB-aR5"/>
                 <constraint firstAttribute="trailing" secondItem="Xvt-tP-TbR" secondAttribute="trailing" constant="20" id="anU-nC-YAw"/>
+                <constraint firstAttribute="bottom" secondItem="mpG-iq-bhB" secondAttribute="bottom" constant="20" symbolic="YES" id="eMc-ND-ynq"/>
                 <constraint firstAttribute="trailing" secondItem="CLc-Vg-aWg" secondAttribute="trailing" constant="20" symbolic="YES" id="fXu-pq-O8Q"/>
                 <constraint firstAttribute="trailing" secondItem="mpG-iq-bhB" secondAttribute="trailing" constant="20" symbolic="YES" id="gi4-jv-uIS"/>
                 <constraint firstItem="mpG-iq-bhB" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="p1V-P9-mcG"/>
                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="564" id="pZq-NN-J9o"/>
+                <constraint firstItem="mpG-iq-bhB" firstAttribute="top" secondItem="CLc-Vg-aWg" secondAttribute="bottom" constant="8" symbolic="YES" id="rXR-J6-CAc"/>
                 <constraint firstItem="CLc-Vg-aWg" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="wyw-aC-Vkj"/>
                 <constraint firstItem="8Z8-mS-hfg" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="xdM-IO-cz3"/>
             </constraints>
-            <point key="canvasLocation" x="-906.5" y="-146"/>
+            <point key="canvasLocation" x="-906.5" y="-138"/>
         </customView>
     </objects>
 </document>

--- a/MacPass/DDHotKey+MacPassAdditions.m
+++ b/MacPass/DDHotKey+MacPassAdditions.m
@@ -37,7 +37,9 @@
 
 + (NSData *)defaultHotKeyData {
   return [self hotKeyDataWithKeyCode:kVK_ANSI_M modifierFlags:kCGEventFlagMaskControl|kCGEventFlagMaskAlternate];
+
 }
+
 
 + (instancetype)defaultHotKey {
   return [DDHotKey defaultHotKeyWithTask:nil];

--- a/MacPass/MPAppDelegate.m
+++ b/MacPass/MPAppDelegate.m
@@ -43,6 +43,7 @@
 #import "MPPlugin.h"
 #import "MPEntryContextMenuDelegate.h"
 #import "MPAutotypeDoctor.h"
+#import "MPHotkey.h"
 
 #import "NSApplication+MPAdditions.h"
 #import "NSTextView+MPTouchBarExtension.h"
@@ -214,6 +215,7 @@ typedef NS_OPTIONS(NSInteger, MPAppStartupState) {
   /* Initalizes Global Daemons */
   [MPLockDaemon defaultDaemon];
   [MPAutotypeDaemon defaultDaemon];
+  [MPHotkeyDaemon hotkeyDaemon];
   [MPPluginHost sharedHost];
 #if !defined(DEBUG) && !defined(NO_SPARKLE)
   /* Disable updates if in debug or nosparkle  */

--- a/MacPass/MPHotkey.h
+++ b/MacPass/MPHotkey.h
@@ -1,9 +1,8 @@
 //
-//  MPWorkflowSettingsController.h
+//  MPHotkey.h
 //  MacPass
 //
-//  Created by Michael Starke on 30.07.13.
-//  Copyright (c) 2013 HicknHack Software GmbH. All rights reserved.
+//  Created by George Snow on 7.1.2022.
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -20,16 +19,18 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#import "MPViewController.h"
-#import "MPPreferencesTab.h"
+#import <Foundation/Foundation.h>
 
-@class DDHotKeyTextField;
+@class DDHotKey;
+/**
+ *  The hotkey  is responsible for registering the global hotkey and to perform any autotype actions
+ */
+@interface MPHotkeyDaemon : NSObject
 
-@interface MPWorkflowPreferencesController : MPViewController <MPPreferencesTab>
-
-@property (strong) IBOutlet DDHotKeyTextField *hotkeyTextField;
-@property (strong) IBOutlet NSTextField *hotkeyWarningTextField;
-
+@property (strong) IBOutlet NSWindow *matchSelectionWindow;
+@property (weak) IBOutlet NSPopUpButton *matchSelectionButton;
+@property (readonly, strong) DDHotKey *registredHotKey;
+@property (readonly, strong, class) MPHotkeyDaemon *hotkeyDaemon;
 
 
 @end

--- a/MacPass/MPHotkey.h
+++ b/MacPass/MPHotkey.h
@@ -23,7 +23,7 @@
 
 @class DDHotKey;
 /**
- *  The hotkey  is responsible for registering the global hotkey and to perform any autotype actions
+ *  The hotkey  is responsible for registering the global hotkey and to to show/hide MacPass
  */
 @interface MPHotkeyDaemon : NSObject
 

--- a/MacPass/MPHotkey.m
+++ b/MacPass/MPHotkey.m
@@ -25,6 +25,10 @@
 #import "MPPluginHost.h"
 #import "MPPlugin.h"
 
+#import "MPDocument.h"
+#import "MPDocumentWindowController.h"
+#import "MPDocumentController.h"
+
 #import "NSApplication+MPAdditions.h"
 #import "NSUserNotification+MPAdditions.h"
 
@@ -76,6 +80,9 @@ static MPHotkeyDaemon *_sharedInstance;
       toObject:NSUserDefaultsController.sharedUserDefaultsController
    withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowHideKeyDataKey]
        options:nil];
+
+
+    
     
   }
   return self;
@@ -134,13 +141,32 @@ static MPHotkeyDaemon *_sharedInstance;
 - (void)_didPressHotKey {
 
   bool mpActive = [NSApp isActive];
+  BOOL focusSearchAfterHotkey = [NSUserDefaults.standardUserDefaults boolForKey:kMPSettingsKeyFocusSearchAfterHotkey];
+  
   if(mpActive) {
-    [NSApplication.sharedApplication hide:nil];
-  }
+      [NSApplication.sharedApplication hide:nil];
+    }
   else {
-    [NSApplication.sharedApplication activateIgnoringOtherApps:YES];
-    
-  }
+      [NSApplication.sharedApplication activateIgnoringOtherApps:YES];
+      
 
+      
+      if(focusSearchAfterHotkey) {
+        [self _focusSearchAfterHotkey];
+    }
+      
+  }
+  
+}
+- (void)_focusSearchAfterHotkey {
+
+  NSArray *documents = [NSDocumentController sharedDocumentController].documents;
+  NSPredicate *filterPredicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nonnull evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+    MPDocument *document = evaluatedObject;
+    return !document.encrypted;}];
+  NSArray *unlockedDocuments = [documents filteredArrayUsingPredicate:filterPredicate];
+  [unlockedDocuments makeObjectsPerformSelector:@selector(performCustomSearch:)];
+
+  
 }
 @end

--- a/MacPass/MPHotkey.m
+++ b/MacPass/MPHotkey.m
@@ -80,7 +80,12 @@ static MPHotkeyDaemon *_sharedInstance;
       toObject:NSUserDefaultsController.sharedUserDefaultsController
    withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowHideKeyDataKey]
        options:nil];
+    
 
+    BOOL hotkeyStatus = [NSUserDefaults.standardUserDefaults boolForKey:kMPSettingsKeyShowOrHideMacPass];
+    if(!hotkeyStatus){
+      [NSUserDefaults.standardUserDefaults setBool:!hotkeyStatus forKey:kMPSettingsKeyFocusSearchAfterHotkey];
+    }
 
     
     

--- a/MacPass/MPHotkey.m
+++ b/MacPass/MPHotkey.m
@@ -1,0 +1,150 @@
+//
+//  MPHotkey.m
+//  MacPass
+//
+//  Created by George Snow on 7.1.2022.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#import "MPHotkey.h"
+#import "MPSettingsHelper.h"
+
+#import "MPPluginHost.h"
+#import "MPPlugin.h"
+
+#import "NSApplication+MPAdditions.h"
+#import "NSUserNotification+MPAdditions.h"
+
+#import "DDHotKeyCenter.h"
+#import "DDHotKey+MacPassAdditions.h"
+
+#import "KeePassKit/KeePassKit.h"
+#import <Carbon/Carbon.h>
+
+@interface MPHotkeyDaemon ()
+
+@property (nonatomic, assign) BOOL enabled;
+@property (nonatomic, copy) NSData *hotKeyData;
+@property (strong) DDHotKey *registredHotKey;
+
+@end
+
+@implementation MPHotkeyDaemon
+
+#pragma mark -
+#pragma mark Lifecylce
+
+static MPHotkeyDaemon *_sharedInstance;
+
++ (instancetype)hotkeyDaemon {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    _sharedInstance = [[MPHotkeyDaemon alloc] _init];
+  });
+  return _sharedInstance;
+}
+
+- (instancetype)init {
+  return nil;
+}
+
+- (instancetype)_init {
+  NSAssert(_sharedInstance == nil, @"Multiple initializations not allowed on singleton");
+  self = [super init];
+  if (self) {
+    _enabled = NO;
+    //_userActionRequested = NSDate.distantPast.timeIntervalSinceReferenceDate;
+    [self bind:NSStringFromSelector(@selector(enabled))
+      toObject:NSUserDefaultsController.sharedUserDefaultsController
+   withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowOrHideMacPass]
+       options:nil];
+    
+    [self bind:NSStringFromSelector(@selector(hotKeyData))
+      toObject:NSUserDefaultsController.sharedUserDefaultsController
+   withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowHideKeyDataKey]
+       options:nil];
+    
+//    [NSWorkspace.sharedWorkspace.notificationCenter addObserver:self
+//                                                       selector:@selector(_didDeactivateApplication:)
+//                                                           name:NSWorkspaceDidDeactivateApplicationNotification
+//                                                         object:nil];
+  }
+  return self;
+}
+
+- (void)dealloc {
+
+  [self unbind:NSStringFromSelector(@selector(enabled))];
+  [self unbind:NSStringFromSelector(@selector(hotKeyData))];
+}
+
+#pragma mark -
+#pragma mark Properties
+
+- (void)setEnabled:(BOOL)enabled {
+  if(_enabled != enabled) {
+    _enabled = enabled;
+    self.enabled ? [self _registerHotKey] : [self _unregisterHotKey];
+  }
+}
+
+- (void)setHotKeyData:(NSData *)hotKeyData {
+  if(![_hotKeyData isEqualToData:hotKeyData]) {
+    [self _unregisterHotKey];
+    _hotKeyData = [hotKeyData copy];
+    if(self.enabled) {
+      [self _registerHotKey];
+    }
+  }
+}
+
+#pragma mark -
+#pragma mark Hotkey Registration
+- (void)_registerHotKey {
+  if(!self.hotKeyData) {
+    return;
+  }
+  __weak MPHotkeyDaemon *welf = self;
+  DDHotKeyTask aTask = ^(NSEvent *event) {
+    [welf _didPressHotKey];
+  };
+  self.registredHotKey = [[DDHotKeyCenter sharedHotKeyCenter] registerHotKey:[DDHotKey hotKeyWithKeyData:self.hotKeyData task:aTask]];
+}
+
+- (void)_unregisterHotKey {
+  if(self.registredHotKey) {
+    [[DDHotKeyCenter sharedHotKeyCenter] unregisterHotKey:self.registredHotKey];
+    self.registredHotKey = nil;
+  }
+}
+
+#pragma mark -
+#pragma mark Show/Hide Invocation
+
+
+- (void)_didPressHotKey {
+
+  bool mpActive = [NSApp isActive];
+  if(mpActive) {
+    [NSApplication.sharedApplication hide:nil];
+  }
+  else {
+    [NSApplication.sharedApplication activateIgnoringOtherApps:YES];
+    
+  }
+
+}
+@end

--- a/MacPass/MPHotkey.m
+++ b/MacPass/MPHotkey.m
@@ -142,6 +142,9 @@ static MPHotkeyDaemon *_sharedInstance;
 
   bool mpActive = [NSApp isActive];
   BOOL focusSearchAfterHotkey = [NSUserDefaults.standardUserDefaults boolForKey:kMPSettingsKeyFocusSearchAfterHotkey];
+
+
+
   
   if(mpActive) {
       [NSApplication.sharedApplication hide:nil];

--- a/MacPass/MPHotkey.m
+++ b/MacPass/MPHotkey.m
@@ -77,10 +77,6 @@ static MPHotkeyDaemon *_sharedInstance;
    withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowHideKeyDataKey]
        options:nil];
     
-//    [NSWorkspace.sharedWorkspace.notificationCenter addObserver:self
-//                                                       selector:@selector(_didDeactivateApplication:)
-//                                                           name:NSWorkspaceDidDeactivateApplicationNotification
-//                                                         object:nil];
   }
   return self;
 }

--- a/MacPass/MPSettingsHelper.h
+++ b/MacPass/MPSettingsHelper.h
@@ -35,6 +35,9 @@ APPKIT_EXTERN NSString *const kMPSettingsKeyQuitOnLastWindowClose;          // Q
 APPKIT_EXTERN NSString *const kMPSettingsKeyFileChangeStrategy;
 APPKIT_EXTERN NSString *const kMPSettingsKeyEnableAutosave;                 // if set to YES MacPass support Autosaving for documents
 APPKIT_EXTERN NSString *const kMPSettingsKeyFocusSearchAfterUnlock;         // Enter search after unlocking the database
+APPKIT_EXTERN NSString *const kMPSettingsKeyShowOrHideMacPass;
+    // Enable hotkey for showing or hiding MacPass
+   
 
 /* Entry Table Display */
 APPKIT_EXTERN NSString *const kMPSettingsKeyDisplayClearTextPasswordsInEntryList;
@@ -94,6 +97,7 @@ APPKIT_EXTERN NSString *const kMPSettingsKeyLoadUnsecurePlugins;            // I
 APPKIT_EXTERN NSString *const kMPSettingsKeyDisabledPlugins;                // NSArray of bundle identifiers of disabled plugins
 APPKIT_EXTERN NSString *const kMPSettingsKeyLoadIncompatiblePlugins;        // If set to YES incompatible plugins (no version info, marked as incompatible, etc) will be loaded regardless
 APPKIT_EXTERN NSString *const kMPSettingsKeyHideIncopatiblePluginsWarning;  // Do not show an alert, when MacPass encounteres incompatible plugins
+APPKIT_EXTERN NSString *const kMPSettingsKeyShowHideKeyDataKey;                   // The stored Data for the user defined show/hide key for MacPass
 APPKIT_EXTERN NSString *const kMPSettingsKeyAllowRemoteFetchOfPluginRepository; // Allow the download of the plugin repository file
 
 /* Network */

--- a/MacPass/MPSettingsHelper.h
+++ b/MacPass/MPSettingsHelper.h
@@ -37,7 +37,8 @@ APPKIT_EXTERN NSString *const kMPSettingsKeyEnableAutosave;                 // i
 APPKIT_EXTERN NSString *const kMPSettingsKeyFocusSearchAfterUnlock;         // Enter search after unlocking the database
 APPKIT_EXTERN NSString *const kMPSettingsKeyShowOrHideMacPass;
     // Enable hotkey for showing or hiding MacPass
-   
+APPKIT_EXTERN NSString *const kMPSettingsKeyFocusSearchAfterHotkey;         // Enter search after hotkey activate for the current database
+
 
 /* Entry Table Display */
 APPKIT_EXTERN NSString *const kMPSettingsKeyDisplayClearTextPasswordsInEntryList;

--- a/MacPass/MPSettingsHelper.m
+++ b/MacPass/MPSettingsHelper.m
@@ -39,6 +39,8 @@ NSString *const kMPSettingsKeyEnableAutosave                              = @"En
 NSString *const kMPSettingsKeyFocusSearchAfterUnlock                      = @"FocusSearchAfterUnlock";
 NSString *const kMPSettingsKeyShowOrHideMacPass                           = @"ShowOrHideMacPass";
 NSString *const kMPSettingsKeyShowHideKeyDataKey                          = @"ShowHideKeyDataKey";
+NSString *const kMPSettingsKeyFocusSearchAfterHotkey                      = @"FocusSearchAfterHotkey";
+
 
 NSString *const kMPSettingsKeyDisplayClearTextPasswordsInEntryList        = @"DisplayClearTextPasswordsInEntryList";
 
@@ -184,6 +186,7 @@ NSString *const kMPDepricatedSettingsKeyAutotypeHideAccessibiltyWarning   = @"Au
       kMPSettingsKeyFocusSearchAfterUnlock: @NO, // Do not enter search directly after unlocking the database
       kMPSettingsKeyShowOrHideMacPass: @NO, // Do not enable hotkey by default
       kMPSettingsKeyShowHideKeyDataKey: DDHotKey.defaultHotKeyData, // Empty - No default hotkey
+      kMPSettingsKeyFocusSearchAfterHotkey: @NO, // Enter search directly after hotkey the database
       kMPSettingsKeyUsePrivateBrowsingWhenOpeningURLs: @NO // No private mode when option URLs by default
     };
   });

--- a/MacPass/MPSettingsHelper.m
+++ b/MacPass/MPSettingsHelper.m
@@ -37,6 +37,8 @@ NSString *const kMPSettingsKeyQuitOnLastWindowClose                       = @"Qu
 NSString *const kMPSettingsKeyFileChangeStrategy                          = @"FileChangeStrategy";
 NSString *const kMPSettingsKeyEnableAutosave                              = @"EnableAutosave";
 NSString *const kMPSettingsKeyFocusSearchAfterUnlock                      = @"FocusSearchAfterUnlock";
+NSString *const kMPSettingsKeyShowOrHideMacPass                           = @"ShowOrHideMacPass";
+NSString *const kMPSettingsKeyShowHideKeyDataKey                          = @"ShowHideKeyDataKey";
 
 NSString *const kMPSettingsKeyDisplayClearTextPasswordsInEntryList        = @"DisplayClearTextPasswordsInEntryList";
 
@@ -180,6 +182,8 @@ NSString *const kMPDepricatedSettingsKeyAutotypeHideAccessibiltyWarning   = @"Au
       kMPSettingsKeyGloablAutotypeAlwaysShowCandidateSelection: @NO,
       kMPSettingsKeyUseUnifiedToolbar: @YES, // Do not use unified toolbar under Big Sur and above
       kMPSettingsKeyFocusSearchAfterUnlock: @NO, // Do not enter search directly after unlocking the database
+      kMPSettingsKeyShowOrHideMacPass: @NO, // Do not enable hotkey by default
+      kMPSettingsKeyShowHideKeyDataKey: DDHotKey.defaultHotKeyData, // Empty - No default hotkey
       kMPSettingsKeyUsePrivateBrowsingWhenOpeningURLs: @NO // No private mode when option URLs by default
     };
   });

--- a/MacPass/MPWorkflowPreferencesController.m
+++ b/MacPass/MPWorkflowPreferencesController.m
@@ -24,7 +24,14 @@
 
 #import "MPSettingsHelper.h"
 
+#import "DDHotKeyCenter.h"
+#import "DDHotKey+MacPassAdditions.h"
+#import "DDHotKeyTextField.h"
+
+
 @interface MPWorkflowPreferencesController ()
+
+
 
 @property (strong) IBOutlet NSPopUpButton *browserPopup;
 @property (strong) IBOutlet NSPopUpButton *doubleClickURLPopup;
@@ -33,7 +40,10 @@
 @property (strong) IBOutlet NSButton *generatePasswordOnEntriesCheckButton;
 @property (strong) IBOutlet NSButton *hideAfterCopyToClipboardCheckButton;
 @property (strong) IBOutlet NSButton *focusSearchAfterUnlockCheckButton;
+
 //@property (strong) IBOutlet NSButton *privateBrowsingCheckButton;
+@property (strong) IBOutlet NSButton *showOrHideMacPassCheckButton;
+@property (nonatomic, strong) DDHotKey *hotKey;
 
 - (IBAction)_showCustomBrowserSelection:(id)sender;
 
@@ -76,6 +86,13 @@
 //                               toObject:defaultsController
 //                            withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyUsePrivateBrowsingWhenOpeningURLs]
 //                                options:nil];
+  
+  [self.showOrHideMacPassCheckButton bind:NSValueBinding
+                                      toObject:defaultsController
+                                   withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowOrHideMacPass]
+                                       options:nil];
+  self.hotkeyTextField.delegate = self;
+  
   [self _updateBrowserSelection];
 }
 
@@ -94,7 +111,32 @@
 
 - (void)willShowTab {
   [self _updateBrowserSelection];
+  if(!_hotKey) {
+    _hotKey = [DDHotKey hotKeyWithKeyData:[NSUserDefaults.standardUserDefaults dataForKey:kMPSettingsKeyShowHideKeyDataKey]];
+  }
+  /* Only call the setter if the hotkeys are different, otherwise the dealloc call will unregister them*/
+  if(![self.hotkeyTextField.hotKey isEqual:self.hotKey]) {
+    self.hotkeyTextField.hotKey = self.hotKey;
+  }
 }
+
+#pragma mark -
+#pragma mark Properties
+- (void)setHotKey:(DDHotKey *)hotKey {
+  if([self.hotKey isEqual:hotKey]) {
+    NSLog(@"hotkey IS already set");
+    return; // Nothing of interest has changed;
+  }
+  NSLog(@"hotkey set");
+  _hotKey = hotKey;
+  
+  [NSUserDefaults.standardUserDefaults setObject:self.hotKey.keyData forKey:kMPSettingsKeyShowHideKeyDataKey];
+}
+
+- (void)_showKeyCodeMissingKeyWarning:(BOOL)show {
+  self.hotkeyWarningTextField.hidden = !show;
+}
+
 
 #pragma mark Actions
 - (void)_selectBrowser:(id)sender {
@@ -199,5 +241,16 @@
   NSArray *browserBundles = CFBridgingRelease(LSCopyAllHandlersForURLScheme(CFSTR("https")));
   return browserBundles;
 }
+
+- (void)controlTextDidChange:(NSNotification *)obj {
+  BOOL validHotKey = self.hotkeyTextField.hotKey.valid;
+  [self _showKeyCodeMissingKeyWarning:!validHotKey];
+  if(validHotKey) {
+    self.hotKey = self.hotkeyTextField.hotKey;
+  }
+}
+
+
+
 
 @end

--- a/MacPass/MPWorkflowPreferencesController.m
+++ b/MacPass/MPWorkflowPreferencesController.m
@@ -97,6 +97,7 @@
                            toObject:defaultsController
                         withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyFocusSearchAfterHotkey]
                             options:nil];
+  [self.focusSearchAfterHotkey bind:NSEnabledBinding toObject:defaultsController withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowOrHideMacPass] options:nil];
 
   
   self.hotkeyTextField.delegate = self;

--- a/MacPass/MPWorkflowPreferencesController.m
+++ b/MacPass/MPWorkflowPreferencesController.m
@@ -44,6 +44,8 @@
 //@property (strong) IBOutlet NSButton *privateBrowsingCheckButton;
 @property (strong) IBOutlet NSButton *showOrHideMacPassCheckButton;
 @property (nonatomic, strong) DDHotKey *hotKey;
+@property (strong) IBOutlet NSButtonCell *focusSearchAfterHotkey;
+
 
 - (IBAction)_showCustomBrowserSelection:(id)sender;
 
@@ -91,6 +93,12 @@
                                       toObject:defaultsController
                                    withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyShowOrHideMacPass]
                                        options:nil];
+  [self.focusSearchAfterHotkey bind:NSValueBinding
+                           toObject:defaultsController
+                        withKeyPath:[MPSettingsHelper defaultControllerPathForKey:kMPSettingsKeyFocusSearchAfterHotkey]
+                            options:nil];
+
+  
   self.hotkeyTextField.delegate = self;
   
   [self _updateBrowserSelection];
@@ -118,6 +126,7 @@
   if(![self.hotkeyTextField.hotKey isEqual:self.hotKey]) {
     self.hotkeyTextField.hotKey = self.hotKey;
   }
+
 }
 
 #pragma mark -


### PR DESCRIPTION
this is extension of macpassrevealer functionality. when the hot key is used to unhide/activate MacPass it will default to focusing the search box. This is the similar to how focus search on unlock.

this also needs some tweaking to the constraints in GUI. 

<img width="446" alt="Screen Shot 2022-01-14 at 4 13 14 PM" src="https://user-images.githubusercontent.com/12751441/149585945-17b7c147-1b76-44ad-98ec-c8039f979cf6.png">
 